### PR TITLE
refactor: EasyPost 코드 리뷰 지적사항 수정

### DIFF
--- a/src/main/java/com/conk/integration/command/application/service/EasyPostInvoiceSaveService.java
+++ b/src/main/java/com/conk/integration/command/application/service/EasyPostInvoiceSaveService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -39,8 +41,9 @@ public class EasyPostInvoiceSaveService {
             throw new IllegalStateException("No rates available for shipment");
         }
         return rates.stream()
+                .filter(r -> r.getRate() != null && isNumeric(r.getRate()))
                 .min(Comparator.comparingDouble(r -> Double.parseDouble(r.getRate())))
-                .orElseThrow(() -> new IllegalStateException("No rates available for shipment"));
+                .orElseThrow(() -> new IllegalStateException("No valid rates available for shipment"));
     }
 
     private EasypostShipmentInvoice toInvoice(EasyPostShipmentResponse response) {
@@ -49,9 +52,10 @@ public class EasyPostInvoiceSaveService {
         String trackingUrl = resolveTrackingUrl(response);
         String shipToAddress = resolveShipToAddress(response.getToAddress());
 
-        int freightChargeAmtCents = selected != null && selected.getRate() != null
-                ? (int) Math.round(Double.parseDouble(selected.getRate()) * 100)
-                : 0;
+        int freightChargeAmtCents = 0;
+        if (selected != null && selected.getRate() != null && isNumeric(selected.getRate())) {
+            freightChargeAmtCents = (int) Math.round(Double.parseDouble(selected.getRate()) * 100);
+        }
 
         CarrierType carrierType = selected != null
                 ? resolveCarrierType(selected.getCarrier())
@@ -88,16 +92,17 @@ public class EasyPostInvoiceSaveService {
 
     private String resolveShipToAddress(EasyPostShipmentResponse.AddressDto addr) {
         if (addr == null) return null;
-        return String.join(", ",
-                nullSafe(addr.getStreet1()),
-                nullSafe(addr.getCity()),
-                nullSafe(addr.getState()),
-                nullSafe(addr.getZip()),
-                nullSafe(addr.getCountry())
-        ).replaceAll("^,\\s*|,\\s*$", "").replaceAll(",\\s*,", ",");
+        return Stream.of(addr.getStreet1(), addr.getCity(), addr.getState(), addr.getZip(), addr.getCountry())
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.joining(", "));
     }
 
-    private String nullSafe(String s) {
-        return s != null ? s : "";
+    private boolean isNumeric(String s) {
+        try {
+            Double.parseDouble(s);
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/conk/integration/command/domain/aggregate/EasypostShipmentInvoice.java
+++ b/src/main/java/com/conk/integration/command/domain/aggregate/EasypostShipmentInvoice.java
@@ -52,4 +52,15 @@ public class EasypostShipmentInvoice {
     // schema: VARCHAR(255) — not DATETIME
     @Column(name = "handover_at")
     private String handoverAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/conk/integration/command/infrastructure/service/EasyPostApiClient.java
+++ b/src/main/java/com/conk/integration/command/infrastructure/service/EasyPostApiClient.java
@@ -24,19 +24,23 @@ public class EasyPostApiClient {
 
     private final RestTemplate restTemplate;
     private final EasyPostProperties properties;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;  // Spring Bean 주입
 
     public EasyPostShipmentResponse createShipment(EasyPostCreateShipmentRequest request) {
         try {
             Map<String, Object> body = toRequestMap(request);
             String jsonBody = objectMapper.writeValueAsString(body);
             HttpEntity<String> entity = new HttpEntity<>(jsonBody, buildAuthHeaders());
-            return restTemplate.exchange(
+            EasyPostShipmentResponse response = restTemplate.exchange(
                     properties.getShipmentsUrl(),
                     HttpMethod.POST,
                     entity,
                     EasyPostShipmentResponse.class
             ).getBody();
+            if (response == null) {
+                throw new IllegalStateException("EasyPost createShipment returned empty response");
+            }
+            return response;
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Failed to serialize EasyPost request", e);
         }
@@ -46,12 +50,16 @@ public class EasyPostApiClient {
         try {
             String jsonBody = objectMapper.writeValueAsString(Map.of("rate", Map.of("id", rateId)));
             HttpEntity<String> entity = new HttpEntity<>(jsonBody, buildAuthHeaders());
-            return restTemplate.exchange(
+            EasyPostShipmentResponse response = restTemplate.exchange(
                     properties.getBuyRateUrl(shipmentId),
                     HttpMethod.POST,
                     entity,
                     EasyPostShipmentResponse.class
             ).getBody();
+            if (response == null) {
+                throw new IllegalStateException("EasyPost buyRate returned empty response");
+            }
+            return response;
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Failed to serialize buyRate request", e);
         }
@@ -59,6 +67,9 @@ public class EasyPostApiClient {
 
     private Map<String, Object> toRequestMap(EasyPostCreateShipmentRequest request) {
         EasyPostCreateShipmentRequest.ShipmentBody sb = request.getShipment();
+        if (sb == null) {
+            throw new IllegalArgumentException("ShipmentBody must not be null");
+        }
         Map<String, Object> shipment = new HashMap<>();
         if (sb.getToAddress() != null) {
             shipment.put("to_address", addressToMap(sb.getToAddress()));

--- a/src/test/java/com/conk/integration/command/infrastructure/service/EasyPostApiClientTest.java
+++ b/src/test/java/com/conk/integration/command/infrastructure/service/EasyPostApiClientTest.java
@@ -3,6 +3,7 @@ package com.conk.integration.command.infrastructure.service;
 import com.conk.integration.command.application.dto.request.EasyPostCreateShipmentRequest;
 import com.conk.integration.command.application.dto.response.EasyPostShipmentResponse;
 import com.conk.integration.command.infrastructure.config.EasyPostProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,9 @@ import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -38,7 +42,7 @@ class EasyPostApiClientTest {
         properties.setApiKey(TEST_API_KEY);
         properties.setBaseUrl(BASE_URL);
 
-        client = new EasyPostApiClient(restTemplate, properties);
+        client = new EasyPostApiClient(restTemplate, properties, new ObjectMapper());
     }
 
     // ─────────────────────────────────────────────────────────
@@ -64,12 +68,12 @@ class EasyPostApiClientTest {
     @Test
     @DisplayName("[GREEN] createShipment - Basic Auth 헤더 포함 확인")
     void createShipment_includesBasicAuthHeader() {
+        String expectedAuth = "Basic " + Base64.getEncoder().encodeToString(
+                (TEST_API_KEY + ":").getBytes(StandardCharsets.UTF_8));
+
         mockServer.expect(requestTo(BASE_URL + "/v2/shipments"))
                 .andExpect(method(HttpMethod.POST))
-                .andExpect(header("Authorization", "Basic RVpUS190ZXN0X2tleToK".substring(0,
-                        // just check prefix
-                        0) + "Basic " + java.util.Base64.getEncoder().encodeToString(
-                        (TEST_API_KEY + ":").getBytes(java.nio.charset.StandardCharsets.UTF_8))))
+                .andExpect(header("Authorization", expectedAuth))
                 .andRespond(withSuccess(shipmentResponseJson("shp_test_002"), MediaType.APPLICATION_JSON));
 
         client.createShipment(buildRequest());


### PR DESCRIPTION
## Summary

- **[HIGH-2]** \`EasyPostApiClient\` — \`getBody()\` null 체크 추가 (NPE 방지)
- **[HIGH-3]** \`EasyPostInvoiceSaveService\` — \`Double.parseDouble()\` NumberFormatException 방어 처리 (\`isNumeric()\` 필터)
- **[HIGH-4]** \`EasypostShipmentInvoice\` — \`@PrePersist\` / \`@PreUpdate\` 추가 (\`createdAt\`, \`updatedAt\` NULL 저장 방지)
- **[MEDIUM-1]** \`EasyPostApiClient\` — \`new ObjectMapper()\` 제거, Spring Bean 생성자 주입으로 변경
- **[MEDIUM-3]** \`EasyPostInvoiceSaveService\` — \`resolveShipToAddress\` 정규식 제거, \`Stream.filter + Collectors.joining\`으로 교체
- **[LOW-1]** \`EasyPostApiClientTest\` — Auth 헤더 검증 테스트 \`.substring(0, 0)\` 버그 수정

## Test plan

- [x] \`./gradlew test\` — 전체 단위 테스트 52개 GREEN
