### PR TITLE
refactor: Shopify 코드 리팩터링

### DIFF
--- a/src/main/java/com/conk/integration/command/application/dto/response/ShopifyOrderListResponse.java
+++ b/src/main/java/com/conk/integration/command/application/dto/response/ShopifyOrderListResponse.java
@@ -1,14 +1,12 @@
 package com.conk.integration.command.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.Collections;
 import java.util.List;
 
-@Getter
 @Setter
 @NoArgsConstructor
 public class ShopifyOrderListResponse {

--- a/src/main/java/com/conk/integration/command/application/service/ShopifyOrderSyncService.java
+++ b/src/main/java/com/conk/integration/command/application/service/ShopifyOrderSyncService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.function.Function;
 
 @Slf4j
 @Service
@@ -41,8 +42,7 @@ public class ShopifyOrderSyncService {
                 continue;
             }
 
-            ChannelOrder order = toChannelOrder(dto, sellerId);
-            channelOrderRepository.save(order);
+            channelOrderRepository.save(toChannelOrder(dto, sellerId));
             log.debug("주문 저장 완료: {} ({})", orderId, dto.getName());
         }
     }
@@ -55,17 +55,20 @@ public class ShopifyOrderSyncService {
                 .channelOrderNo(dto.getName())
                 .orderChannel(OrderChannel.SHOPIFY)
                 .orderedAt(parseDateTime(dto.getCreatedAt()))
-                .receiverName(addr != null ? addr.getName() : null)
-                .receiverPhoneNo(addr != null ? addr.getPhone() : null)
-                .shipToAddress1(addr != null ? addr.getAddress1() : null)
-                .shipToAddress2(addr != null ? addr.getAddress2() : null)
-                .shipToState(addr != null ? addr.getProvinceCode() : null)
-                .shipToCity(addr != null ? addr.getCity() : null)
-                .shipToZipCode(addr != null ? addr.getZip() : null)
+                .receiverName(addrField(addr, ShopifyOrderDto.ShippingAddress::getName))
+                .receiverPhoneNo(addrField(addr, ShopifyOrderDto.ShippingAddress::getPhone))
+                .shipToAddress1(addrField(addr, ShopifyOrderDto.ShippingAddress::getAddress1))
+                .shipToAddress2(addrField(addr, ShopifyOrderDto.ShippingAddress::getAddress2))
+                .shipToState(addrField(addr, ShopifyOrderDto.ShippingAddress::getProvinceCode))
+                .shipToCity(addrField(addr, ShopifyOrderDto.ShippingAddress::getCity))
+                .shipToZipCode(addrField(addr, ShopifyOrderDto.ShippingAddress::getZip))
                 .sellerId(sellerId)
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
                 .build();
+    }
+
+    private <T> T addrField(ShopifyOrderDto.ShippingAddress addr,
+                             Function<ShopifyOrderDto.ShippingAddress, T> getter) {
+        return addr != null ? getter.apply(addr) : null;
     }
 
     private LocalDateTime parseDateTime(String dateStr) {

--- a/src/main/java/com/conk/integration/command/domain/aggregate/ChannelOrder.java
+++ b/src/main/java/com/conk/integration/command/domain/aggregate/ChannelOrder.java
@@ -83,4 +83,15 @@ public class ChannelOrder {
     public void addItem(ChannelOrderItem item) {
         items.add(item);
     }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/conk/integration/command/infrastructure/service/ShopifyApiClient.java
+++ b/src/main/java/com/conk/integration/command/infrastructure/service/ShopifyApiClient.java
@@ -39,6 +39,10 @@ public class ShopifyApiClient {
         ResponseEntity<ShopifyOrderListResponse> response = restTemplate.exchange(
                 url, HttpMethod.GET, new HttpEntity<>(headers), ShopifyOrderListResponse.class);
 
-        return response.getBody().getOrders();
+        ShopifyOrderListResponse body = response.getBody();
+        if (body == null) {
+            throw new IllegalStateException("Shopify API returned empty response");
+        }
+        return body.getOrders();
     }
 }


### PR DESCRIPTION
## Summary

- **[ShopifyApiClient]** \`getBody()\` null 체크 추가 — response가 null이면 \`IllegalStateException\` 발생 (NPE 방지)
- **[ShopifyOrderListResponse]** 중복 \`@Getter\` 제거 — 수동 정의된 \`getOrders()\`가 있어 Lombok \`@Getter\`가 무효였던 문제 해소
- **[ChannelOrder]** \`@PrePersist\` / \`@PreUpdate\` 추가 — \`createdAt\`, \`updatedAt\` 자동 설정 (NULL 저장 방지)
- **[ShopifyOrderSyncService]** \`toChannelOrder()\` 리팩터링
  - \`addr != null ? addr.getX() : null\` 7회 반복 패턴 → \`addrField()\` 헬퍼로 추출
  - 빌더에서 \`createdAt/updatedAt\` 수동 설정 제거 (\`@PrePersist\` 위임)

## Test plan

- [x] \`./gradlew test\` — 전체 단위 테스트 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)