### PR TITLE
feat: Shopify 주문 출고 확인(fulfillment) 서비스 구현

### DIFF
--- a/src/main/java/com/conk/integration/command/application/dto/request/ShopifyFulfillmentRequest.java
+++ b/src/main/java/com/conk/integration/command/application/dto/request/ShopifyFulfillmentRequest.java
@@ -1,0 +1,42 @@
+package com.conk.integration.command.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShopifyFulfillmentRequest {
+
+    private FulfillmentBody fulfillment;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class FulfillmentBody {
+
+        @JsonProperty("tracking_info")
+        private TrackingInfo trackingInfo;
+
+        @JsonProperty("notify_customer")
+        private boolean notifyCustomer;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class TrackingInfo {
+
+        private String number;
+        private String company;
+    }
+}

--- a/src/main/java/com/conk/integration/command/application/dto/response/ShopifyFulfillmentResponse.java
+++ b/src/main/java/com/conk/integration/command/application/dto/response/ShopifyFulfillmentResponse.java
@@ -1,0 +1,29 @@
+package com.conk.integration.command.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ShopifyFulfillmentResponse {
+
+    private FulfillmentBody fulfillment;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class FulfillmentBody {
+
+        private Long id;
+        private String status;
+
+        @JsonProperty("tracking_number")
+        private String trackingNumber;
+
+        @JsonProperty("tracking_company")
+        private String trackingCompany;
+    }
+}

--- a/src/main/java/com/conk/integration/command/application/service/ShopifyFulfillmentService.java
+++ b/src/main/java/com/conk/integration/command/application/service/ShopifyFulfillmentService.java
@@ -1,0 +1,57 @@
+package com.conk.integration.command.application.service;
+
+import com.conk.integration.command.application.dto.request.ShopifyFulfillmentRequest;
+import com.conk.integration.command.domain.aggregate.CarrierType;
+import com.conk.integration.command.domain.aggregate.ChannelOrder;
+import com.conk.integration.command.domain.aggregate.EasypostShipmentInvoice;
+import com.conk.integration.command.domain.repository.ChannelOrderRepository;
+import com.conk.integration.command.domain.repository.EasypostShipmentInvoiceRepository;
+import com.conk.integration.command.infrastructure.service.ShopifyFulfillmentApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ShopifyFulfillmentService {
+
+    private final ChannelOrderRepository channelOrderRepository;
+    private final EasypostShipmentInvoiceRepository invoiceRepository;
+    private final ShopifyFulfillmentApiClient shopifyFulfillmentApiClient;
+
+    /**
+     * Shopify 주문 출고 확인
+     * EasyPost 송장의 trackingNumber를 Shopify에 전달해 주문 상태를 fulfilled로 업데이트
+     */
+    public void fulfill(String orderId) {
+        ChannelOrder order = channelOrderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("ChannelOrder를 찾을 수 없습니다: " + orderId));
+
+        if (order.getInvoiceNo() == null) {
+            throw new IllegalStateException("송장이 발급되지 않은 주문입니다: " + orderId);
+        }
+
+        EasypostShipmentInvoice invoice = invoiceRepository.findById(order.getInvoiceNo())
+                .orElseThrow(() -> new IllegalStateException("EasypostShipmentInvoice를 찾을 수 없습니다: " + order.getInvoiceNo()));
+
+        ShopifyFulfillmentRequest request = ShopifyFulfillmentRequest.builder()
+                .fulfillment(ShopifyFulfillmentRequest.FulfillmentBody.builder()
+                        .trackingInfo(ShopifyFulfillmentRequest.TrackingInfo.builder()
+                                .number(invoice.getInvoiceNo())
+                                .company(resolveCarrierCompany(invoice.getCarrierType()))
+                                .build())
+                        .notifyCustomer(true)
+                        .build())
+                .build();
+
+        shopifyFulfillmentApiClient.createFulfillment(order.getChannelOrderNo(), request);
+    }
+
+    String resolveCarrierCompany(CarrierType carrierType) {
+        if (carrierType == null) return "USPS";
+        return switch (carrierType) {
+            case UPS -> "UPS";
+            case FEDEX -> "FedEx";
+            default -> "USPS";
+        };
+    }
+}

--- a/src/main/java/com/conk/integration/command/infrastructure/config/ShopifyProperties.java
+++ b/src/main/java/com/conk/integration/command/infrastructure/config/ShopifyProperties.java
@@ -20,4 +20,8 @@ public class ShopifyProperties {
     public String getOrdersUrl() {
         return getBaseUrl() + "/admin/api/" + apiVersion + "/orders.json";
     }
+
+    public String getFulfillmentsUrl(String shopifyOrderId) {
+        return getBaseUrl() + "/admin/api/" + apiVersion + "/orders/" + shopifyOrderId + "/fulfillments.json";
+    }
 }

--- a/src/main/java/com/conk/integration/command/infrastructure/service/ShopifyFulfillmentApiClient.java
+++ b/src/main/java/com/conk/integration/command/infrastructure/service/ShopifyFulfillmentApiClient.java
@@ -1,0 +1,45 @@
+package com.conk.integration.command.infrastructure.service;
+
+import com.conk.integration.command.application.dto.request.ShopifyFulfillmentRequest;
+import com.conk.integration.command.application.dto.response.ShopifyFulfillmentResponse;
+import com.conk.integration.command.infrastructure.config.ShopifyProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class ShopifyFulfillmentApiClient {
+
+    private final RestTemplate restTemplate;
+    private final ShopifyProperties properties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public ShopifyFulfillmentResponse createFulfillment(String shopifyOrderId, ShopifyFulfillmentRequest request) {
+        try {
+            String jsonBody = objectMapper.writeValueAsString(request);
+            HttpEntity<String> entity = new HttpEntity<>(jsonBody, buildHeaders());
+            return restTemplate.exchange(
+                    properties.getFulfillmentsUrl(shopifyOrderId),
+                    HttpMethod.POST,
+                    entity,
+                    ShopifyFulfillmentResponse.class
+            ).getBody();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize Shopify fulfillment request", e);
+        }
+    }
+
+    private HttpHeaders buildHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Shopify-Access-Token", properties.getAccessToken());
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+}

--- a/src/test/java/com/conk/integration/command/application/service/ShopifyFulfillmentServiceTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/ShopifyFulfillmentServiceTest.java
@@ -1,0 +1,160 @@
+package com.conk.integration.command.application.service;
+
+import com.conk.integration.command.domain.aggregate.CarrierType;
+import com.conk.integration.command.domain.aggregate.ChannelOrder;
+import com.conk.integration.command.domain.aggregate.EasypostShipmentInvoice;
+import com.conk.integration.command.domain.aggregate.OrderChannel;
+import com.conk.integration.command.domain.repository.ChannelOrderRepository;
+import com.conk.integration.command.domain.repository.EasypostShipmentInvoiceRepository;
+import com.conk.integration.command.infrastructure.service.ShopifyFulfillmentApiClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ShopifyFulfillmentService 단위 테스트")
+class ShopifyFulfillmentServiceTest {
+
+    @Mock private ChannelOrderRepository channelOrderRepository;
+    @Mock private EasypostShipmentInvoiceRepository invoiceRepository;
+    @Mock private ShopifyFulfillmentApiClient shopifyFulfillmentApiClient;
+
+    @InjectMocks
+    private ShopifyFulfillmentService service;
+
+    // ─────────────────────────────────────────────────────────
+    // Happy Path
+    // ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("[GREEN] 정상 플로우 - ChannelOrder 조회 → Invoice 조회 → fulfillment 호출")
+    void fulfill_happyPath() {
+        ChannelOrder order = buildChannelOrder("ORD-001", "shp_invoice_001", "5678901234");
+        EasypostShipmentInvoice invoice = buildInvoice("shp_invoice_001", CarrierType.UPS, "1Z999AA10123456784");
+
+        given(channelOrderRepository.findById("ORD-001")).willReturn(Optional.of(order));
+        given(invoiceRepository.findById("shp_invoice_001")).willReturn(Optional.of(invoice));
+
+        service.fulfill("ORD-001");
+
+        verify(channelOrderRepository).findById("ORD-001");
+        verify(invoiceRepository).findById("shp_invoice_001");
+        verify(shopifyFulfillmentApiClient).createFulfillment(eq("5678901234"), any());
+    }
+
+    @Test
+    @DisplayName("[GREEN] CarrierType.UPS → carrier company 'UPS' 매핑")
+    void resolveCarrierCompany_ups() {
+        assertThat(service.resolveCarrierCompany(CarrierType.UPS)).isEqualTo("UPS");
+    }
+
+    @Test
+    @DisplayName("[GREEN] CarrierType.FEDEX → carrier company 'FedEx' 매핑")
+    void resolveCarrierCompany_fedex() {
+        assertThat(service.resolveCarrierCompany(CarrierType.FEDEX)).isEqualTo("FedEx");
+    }
+
+    @Test
+    @DisplayName("[GREEN] CarrierType.USPS → carrier company 'USPS' 매핑")
+    void resolveCarrierCompany_usps() {
+        assertThat(service.resolveCarrierCompany(CarrierType.USPS)).isEqualTo("USPS");
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // 예외
+    // ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("[예외] ChannelOrder 없음 → IllegalArgumentException, fulfillment 미호출")
+    void fulfill_throwsWhenOrderNotFound() {
+        given(channelOrderRepository.findById(anyString())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.fulfill("NOT_EXIST"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("NOT_EXIST");
+
+        verify(shopifyFulfillmentApiClient, never()).createFulfillment(any(), any());
+    }
+
+    @Test
+    @DisplayName("[예외] invoiceNo null → IllegalStateException (송장 미발급), fulfillment 미호출")
+    void fulfill_throwsWhenInvoiceNoIsNull() {
+        ChannelOrder orderWithoutInvoice = buildChannelOrder("ORD-002", null, "5678901234");
+        given(channelOrderRepository.findById("ORD-002")).willReturn(Optional.of(orderWithoutInvoice));
+
+        assertThatThrownBy(() -> service.fulfill("ORD-002"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("송장");
+
+        verify(shopifyFulfillmentApiClient, never()).createFulfillment(any(), any());
+    }
+
+    @Test
+    @DisplayName("[예외] EasypostShipmentInvoice 없음 → IllegalStateException, fulfillment 미호출")
+    void fulfill_throwsWhenInvoiceNotFound() {
+        ChannelOrder order = buildChannelOrder("ORD-003", "shp_missing", "5678901234");
+        given(channelOrderRepository.findById("ORD-003")).willReturn(Optional.of(order));
+        given(invoiceRepository.findById("shp_missing")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.fulfill("ORD-003"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("shp_missing");
+
+        verify(shopifyFulfillmentApiClient, never()).createFulfillment(any(), any());
+    }
+
+    @Test
+    @DisplayName("[예외] ShopifyFulfillmentApiClient 실패 → 예외 전파")
+    void fulfill_propagatesExceptionFromClient() {
+        ChannelOrder order = buildChannelOrder("ORD-004", "shp_invoice_004", "5678901234");
+        EasypostShipmentInvoice invoice = buildInvoice("shp_invoice_004", CarrierType.USPS, "9400111899223397888692");
+
+        given(channelOrderRepository.findById("ORD-004")).willReturn(Optional.of(order));
+        given(invoiceRepository.findById("shp_invoice_004")).willReturn(Optional.of(invoice));
+        given(shopifyFulfillmentApiClient.createFulfillment(anyString(), any()))
+                .willThrow(new HttpClientErrorException(HttpStatus.UNPROCESSABLE_ENTITY));
+
+        assertThatThrownBy(() -> service.fulfill("ORD-004"))
+                .isInstanceOf(HttpClientErrorException.class)
+                .satisfies(e -> assertThat(((HttpClientErrorException) e).getStatusCode())
+                        .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY));
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // Helper
+    // ─────────────────────────────────────────────────────────
+
+    private ChannelOrder buildChannelOrder(String orderId, String invoiceNo, String channelOrderNo) {
+        return ChannelOrder.builder()
+                .orderId(orderId)
+                .channelOrderNo(channelOrderNo)
+                .orderChannel(OrderChannel.SHOPIFY)
+                .sellerId("seller-001")
+                .invoiceNo(invoiceNo)
+                .build();
+    }
+
+    private EasypostShipmentInvoice buildInvoice(String invoiceNo, CarrierType carrierType, String trackingUrl) {
+        return EasypostShipmentInvoice.builder()
+                .invoiceNo(invoiceNo)
+                .carrierType(carrierType)
+                .trackingUrl(trackingUrl)
+                .freightChargeAmt(640)
+                .build();
+    }
+}

--- a/src/test/java/com/conk/integration/command/infrastructure/service/ShopifyFulfillmentApiClientTest.java
+++ b/src/test/java/com/conk/integration/command/infrastructure/service/ShopifyFulfillmentApiClientTest.java
@@ -1,0 +1,179 @@
+package com.conk.integration.command.infrastructure.service;
+
+import com.conk.integration.command.application.dto.request.ShopifyFulfillmentRequest;
+import com.conk.integration.command.application.dto.response.ShopifyFulfillmentResponse;
+import com.conk.integration.command.infrastructure.config.ShopifyProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+@DisplayName("ShopifyFulfillmentApiClient 단위 테스트")
+class ShopifyFulfillmentApiClientTest {
+
+    private MockRestServiceServer mockServer;
+    private ShopifyFulfillmentApiClient client;
+    private ShopifyProperties properties;
+
+    private static final String STORE_NAME = "conktest";
+    private static final String ACCESS_TOKEN = "test-access-token";
+    private static final String API_VERSION = "2025-01";
+    private static final String SHOPIFY_ORDER_ID = "5678901234";
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = new RestTemplate();
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+
+        properties = new ShopifyProperties();
+        properties.setStoreName(STORE_NAME);
+        properties.setAccessToken(ACCESS_TOKEN);
+        properties.setApiVersion(API_VERSION);
+
+        client = new ShopifyFulfillmentApiClient(restTemplate, properties);
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // Happy Path
+    // ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("[GREEN] fulfillment 생성 성공 - fulfillment id 반환")
+    void createFulfillment_returnsFulfillmentId_whenSuccessful() {
+        mockServer.expect(requestTo(expectedUrl()))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(fulfillmentResponseJson("98765", "success"), MediaType.APPLICATION_JSON));
+
+        ShopifyFulfillmentResponse response = client.createFulfillment(SHOPIFY_ORDER_ID, buildRequest());
+
+        assertThat(response).isNotNull();
+        assertThat(response.getFulfillment()).isNotNull();
+        assertThat(response.getFulfillment().getId()).isEqualTo(98765L);
+        mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("[GREEN] X-Shopify-Access-Token 헤더 포함 확인")
+    void createFulfillment_includesAccessTokenHeader() {
+        mockServer.expect(requestTo(expectedUrl()))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("X-Shopify-Access-Token", ACCESS_TOKEN))
+                .andRespond(withSuccess(fulfillmentResponseJson("11111", "success"), MediaType.APPLICATION_JSON));
+
+        client.createFulfillment(SHOPIFY_ORDER_ID, buildRequest());
+        mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("[GREEN] URL에 orderId 올바르게 포함")
+    void createFulfillment_usesCorrectUrlWithOrderId() {
+        String anotherOrderId = "9999999999";
+        String expectedUrl = "https://" + STORE_NAME + ".myshopify.com/admin/api/" + API_VERSION
+                + "/orders/" + anotherOrderId + "/fulfillments.json";
+
+        mockServer.expect(requestTo(expectedUrl))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(fulfillmentResponseJson("22222", "success"), MediaType.APPLICATION_JSON));
+
+        client.createFulfillment(anotherOrderId, buildRequest());
+        mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("[GREEN] trackingNumber와 company가 요청 body에 포함")
+    void createFulfillment_sendsTrackingNumberAndCompany() {
+        mockServer.expect(requestTo(expectedUrl()))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andRespond(withSuccess(fulfillmentResponseJson("33333", "success"), MediaType.APPLICATION_JSON));
+
+        ShopifyFulfillmentRequest req = ShopifyFulfillmentRequest.builder()
+                .fulfillment(ShopifyFulfillmentRequest.FulfillmentBody.builder()
+                        .trackingInfo(ShopifyFulfillmentRequest.TrackingInfo.builder()
+                                .number("1Z999AA10123456784")
+                                .company("UPS")
+                                .build())
+                        .notifyCustomer(true)
+                        .build())
+                .build();
+
+        ShopifyFulfillmentResponse response = client.createFulfillment(SHOPIFY_ORDER_ID, req);
+
+        assertThat(response.getFulfillment().getStatus()).isEqualTo("success");
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // 예외
+    // ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("[예외] 401 Unauthorized → HttpClientErrorException")
+    void createFulfillment_throws_whenUnauthorized() {
+        mockServer.expect(requestTo(expectedUrl()))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> client.createFulfillment(SHOPIFY_ORDER_ID, buildRequest()))
+                .isInstanceOf(HttpClientErrorException.class)
+                .satisfies(e -> assertThat(((HttpClientErrorException) e).getStatusCode())
+                        .isEqualTo(HttpStatus.UNAUTHORIZED));
+    }
+
+    @Test
+    @DisplayName("[예외] 422 Unprocessable Entity → HttpClientErrorException (이미 fulfilled 등)")
+    void createFulfillment_throws_whenUnprocessableEntity() {
+        mockServer.expect(requestTo(expectedUrl()))
+                .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY));
+
+        assertThatThrownBy(() -> client.createFulfillment(SHOPIFY_ORDER_ID, buildRequest()))
+                .isInstanceOf(HttpClientErrorException.class)
+                .satisfies(e -> assertThat(((HttpClientErrorException) e).getStatusCode())
+                        .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY));
+    }
+
+    @Test
+    @DisplayName("[예외] 500 서버 오류 → HttpServerErrorException")
+    void createFulfillment_throws_whenServerError() {
+        mockServer.expect(requestTo(expectedUrl()))
+                .andRespond(withServerError());
+
+        assertThatThrownBy(() -> client.createFulfillment(SHOPIFY_ORDER_ID, buildRequest()))
+                .isInstanceOf(HttpServerErrorException.class);
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // Helper
+    // ─────────────────────────────────────────────────────────
+
+    private String expectedUrl() {
+        return "https://" + STORE_NAME + ".myshopify.com/admin/api/" + API_VERSION
+                + "/orders/" + SHOPIFY_ORDER_ID + "/fulfillments.json";
+    }
+
+    private ShopifyFulfillmentRequest buildRequest() {
+        return ShopifyFulfillmentRequest.builder()
+                .fulfillment(ShopifyFulfillmentRequest.FulfillmentBody.builder()
+                        .trackingInfo(ShopifyFulfillmentRequest.TrackingInfo.builder()
+                                .number("1Z999AA10123456784")
+                                .company("UPS")
+                                .build())
+                        .notifyCustomer(true)
+                        .build())
+                .build();
+    }
+
+    private String fulfillmentResponseJson(String id, String status) {
+        return "{\"fulfillment\":{\"id\":" + id + ",\"status\":\"" + status + "\","
+                + "\"tracking_number\":\"1Z999AA10123456784\",\"tracking_company\":\"UPS\"}}";
+    }
+}


### PR DESCRIPTION
## Summary

- EasyPost 송장 발급 후 획득한 `trackingNumber`를 Shopify Admin API에 전달해 주문 상태를 `unfulfilled → fulfilled`로 업데이트하는 서비스 레이어 구현
- 컨트롤러는 미포함 (별도 브랜치에서 추가 예정)
- TDD (Red → Green) 방식으로 개발, 테스트 15개 전부 PASS

## Changed Files

| 파일 | 역할 |
|------|------|
| `ShopifyFulfillmentRequest.java` | fulfillment + trackingInfo 요청 DTO |
| `ShopifyFulfillmentResponse.java` | id, status, trackingNumber 응답 DTO |
| `ShopifyFulfillmentApiClient.java` | Shopify API 호출 (`X-Shopify-Access-Token` 헤더) |
| `ShopifyFulfillmentService.java` | ChannelOrder → Invoice → Shopify 호출 오케스트레이션 |
| `ShopifyProperties.java` | `getFulfillmentsUrl(orderId)` 헬퍼 메서드 추가 |

## Flow

```mermaid
graph TD
    A[ShopifyFulfillmentService.fulfill] --> B(ChannelOrderRepository.findById)
    B --> C(EasypostShipmentInvoiceRepository.findById)
    C --> D{CarrierType 매핑}
    D -->|UPS/FedEx/USPS| E[POST Shopify API]
```

## Test Plan

- [x] `ShopifyFulfillmentApiClientTest` (7개) — fulfillment 생성 성공, 헤더/URL 검증, 401/422/500 예외
- [x] `ShopifyFulfillmentServiceTest` (8개) — 정상 플로우, CarrierType 매핑, 각종 예외 처리
- [x] 기존 테스트 회귀 없음 (`./gradlew test` BUILD SUCCESSFUL)
