### PR TITLE
feat: 셀러 채널 연결 및 채널별 주문 동기화 API 추가

### DIFF
--- a/src/main/java/com/conk/integration/command/application/controller/IntegrationCommandController.java
+++ b/src/main/java/com/conk/integration/command/application/controller/IntegrationCommandController.java
@@ -5,6 +5,7 @@ import com.conk.integration.command.application.dto.request.BulkInvoiceRequest;
 import com.conk.integration.command.application.dto.request.ChannelOrderSyncRequest;
 import com.conk.integration.command.application.dto.request.EasyPostCreateShipmentRequest;
 import com.conk.integration.command.application.dto.request.ManualOrderInvoiceRequest;
+import com.conk.integration.command.application.dto.request.SellerChannelConnectRequest;
 import com.conk.integration.command.application.dto.response.BulkFulfillmentResponse;
 import com.conk.integration.command.application.dto.response.BulkInvoiceResponse;
 import com.conk.integration.command.application.dto.response.ChannelOrderImportResponse;
@@ -15,11 +16,13 @@ import com.conk.integration.command.application.service.ChannelFulfillmentDispat
 import com.conk.integration.command.application.service.ChannelOrderSyncDispatchService;
 import com.conk.integration.command.application.service.EasyPostInvoiceSaveService;
 import com.conk.integration.command.application.service.ManualOrderInvoiceService;
+import com.conk.integration.command.application.service.SellerChannelConnectService;
 import com.conk.integration.command.domain.aggregate.EasypostShipmentInvoice;
 import com.conk.integration.command.domain.aggregate.enums.OrderChannel;
 import com.conk.integration.common.ApiResponse;
 import com.conk.integration.common.exception.BusinessException;
 import com.conk.integration.common.exception.ErrorCode;
+import com.conk.integration.query.dto.SellerChannelDetailDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,6 +42,21 @@ public class IntegrationCommandController {
     private final EasyPostInvoiceSaveService easyPostInvoiceSaveService;
     private final ChannelOrderSyncDispatchService orderSyncDispatchService;
     private final ManualOrderInvoiceService manualOrderInvoiceService;
+    private final SellerChannelConnectService sellerChannelConnectService;
+
+    /**
+     * 셀러 채널 연결
+     * POST /integrations/seller/channels/{channelKey}/connect
+     */
+    @PostMapping("/seller/channels/{channelKey}/connect")
+    public ResponseEntity<ApiResponse<SellerChannelDetailDto>> connectSellerChannel(
+            @RequestHeader("X-Seller-Id") String sellerId,
+            @PathVariable String channelKey,
+            @RequestBody SellerChannelConnectRequest request) {
+
+        SellerChannelDetailDto response = sellerChannelConnectService.connect(sellerId, channelKey, request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
 
     /**
      * 채널 주문 동기화
@@ -55,6 +73,19 @@ public class IntegrationCommandController {
     }
 
     /**
+     * 채널 주문 동기화
+     * POST /integrations/seller/channels/{channelKey}/sync
+     */
+    @PostMapping("/seller/channels/{channelKey}/sync")
+    public ResponseEntity<ApiResponse<ChannelOrderSyncResponse>> syncChannelOrdersByChannel(
+            @RequestHeader("X-Seller-Id") String sellerId,
+            @PathVariable String channelKey) {
+
+        ChannelOrderSyncResponse response = syncChannelOrdersByChannelKey(sellerId, channelKey);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    /**
      * 채널 주문 가져오기
      * POST /integrations/seller/channels/{channelKey}/import-orders
      */
@@ -63,8 +94,7 @@ public class IntegrationCommandController {
             @RequestHeader("X-Seller-Id") String sellerId,
             @PathVariable String channelKey) {
 
-        OrderChannel orderChannel = toOrderChannel(channelKey);
-        ChannelOrderSyncResponse response = orderSyncDispatchService.sync(sellerId, orderChannel);
+        ChannelOrderSyncResponse response = syncChannelOrdersByChannelKey(sellerId, channelKey);
         return ResponseEntity.ok(ApiResponse.ok(ChannelOrderImportResponse.from(response)));
     }
 
@@ -140,5 +170,10 @@ public class IntegrationCommandController {
                     ErrorCode.UNSUPPORTED_CHANNEL,
                     "지원하지 않는 주문 동기화 채널입니다: " + channelKey);
         }
+    }
+
+    private ChannelOrderSyncResponse syncChannelOrdersByChannelKey(String sellerId, String channelKey) {
+        OrderChannel orderChannel = toOrderChannel(channelKey);
+        return orderSyncDispatchService.sync(sellerId, orderChannel);
     }
 }

--- a/src/main/java/com/conk/integration/command/application/dto/request/SellerChannelConnectRequest.java
+++ b/src/main/java/com/conk/integration/command/application/dto/request/SellerChannelConnectRequest.java
@@ -1,0 +1,18 @@
+package com.conk.integration.command.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 셀러 채널 연결 요청 body를 표현한다.
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SellerChannelConnectRequest {
+
+    private String storeName;
+    private String channelApi;
+    private String storeAlias;
+    private String contactEmail;
+    private String syncMode;
+}

--- a/src/main/java/com/conk/integration/command/application/service/SellerChannelConnectService.java
+++ b/src/main/java/com/conk/integration/command/application/service/SellerChannelConnectService.java
@@ -1,0 +1,92 @@
+package com.conk.integration.command.application.service;
+
+import com.conk.integration.command.application.dto.request.SellerChannelConnectRequest;
+import com.conk.integration.command.domain.aggregate.ChannelApi;
+import com.conk.integration.command.domain.aggregate.embeddable.ChannelApiId;
+import com.conk.integration.command.infrastructure.repository.ChannelApiRepository;
+import com.conk.integration.common.exception.BusinessException;
+import com.conk.integration.common.exception.ErrorCode;
+import com.conk.integration.query.dto.SellerChannelDetailDto;
+import com.conk.integration.query.service.ShopifyPingClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// 셀러 채널 연결 요청을 검증하고 channel_api에 저장한다.
+@Service
+@RequiredArgsConstructor
+public class SellerChannelConnectService {
+
+    private static final String SHOPIFY = "SHOPIFY";
+
+    private final ChannelApiRepository channelApiRepository;
+    private final ShopifyPingClient shopifyPingClient;
+
+    public SellerChannelDetailDto connect(String sellerId, String channelKey, SellerChannelConnectRequest request) {
+        validateSellerId(sellerId);
+        String normalizedChannelKey = normalizeChannelKey(channelKey);
+        validateRequest(request);
+        ensureSupportedChannel(normalizedChannelKey);
+        ensureShopifyConnection(request.getStoreName(), request.getChannelApi());
+
+        ChannelApiId id = new ChannelApiId(sellerId, normalizedChannelKey);
+        ChannelApi channelApi = channelApiRepository.findById(id)
+                .map(existing -> {
+                    existing.updateConnection(request.getChannelApi().trim(), request.getStoreName().trim());
+                    return existing;
+                })
+                .orElseGet(() -> ChannelApi.builder()
+                        .id(id)
+                        .channelApi(request.getChannelApi().trim())
+                        .storeName(request.getStoreName().trim())
+                        .build());
+
+        ChannelApi saved = channelApiRepository.saveAndFlush(channelApi);
+        return new SellerChannelDetailDto(
+                saved.getId().getChannelName(),
+                saved.getStoreName(),
+                saved.getChannelApi(),
+                saved.getAudit() != null ? saved.getAudit().getCreatedAt() : null);
+    }
+
+    private void ensureSupportedChannel(String channelKey) {
+        if (!SHOPIFY.equals(channelKey)) {
+            throw new BusinessException(ErrorCode.UNSUPPORTED_CHANNEL,
+                    "지원하지 않는 채널 연결 채널입니다: " + channelKey);
+        }
+    }
+
+    private void ensureShopifyConnection(String storeName, String channelApi) {
+        if (!shopifyPingClient.ping(storeName.trim(), channelApi.trim())) {
+            throw new BusinessException(ErrorCode.CHANNEL_CONNECTION_NOT_FOUND,
+                    "Shopify 채널 연결에 실패했습니다.");
+        }
+    }
+
+    private void validateSellerId(String sellerId) {
+        if (sellerId == null || sellerId.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_SELLER_ID);
+        }
+    }
+
+    private String normalizeChannelKey(String channelKey) {
+        String normalized = channelKey == null ? "" : channelKey.trim().toUpperCase();
+        if (normalized.isBlank()) {
+            throw new BusinessException(ErrorCode.UNSUPPORTED_CHANNEL, "지원하지 않는 채널 연결 채널입니다: " + channelKey);
+        }
+        return normalized;
+    }
+
+    private void validateRequest(SellerChannelConnectRequest request) {
+        if (request == null) {
+            throw new BusinessException(ErrorCode.INVALID_SELLER_ID, "채널 연결 요청 본문은 필수입니다.");
+        }
+        requireText(request.getStoreName(), "storeName");
+        requireText(request.getChannelApi(), "channelApi");
+    }
+
+    private void requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_SELLER_ID, fieldName + "는 필수입니다.");
+        }
+    }
+}

--- a/src/main/java/com/conk/integration/command/domain/aggregate/ChannelApi.java
+++ b/src/main/java/com/conk/integration/command/domain/aggregate/ChannelApi.java
@@ -5,6 +5,8 @@ import com.conk.integration.command.domain.aggregate.embeddable.ChannelApiId;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 // 셀러가 채널별로 연결한 API 자격 정보를 저장한다.
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,4 +26,21 @@ public class ChannelApi {
     @Embedded
     @Builder.Default
     private AuditFields audit = new AuditFields();
+
+    public void updateConnection(String channelApi, String storeName) {
+        this.channelApi = channelApi;
+        this.storeName = storeName;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        audit.setCreatedAt(now);
+        audit.setUpdatedAt(now);
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        audit.setUpdatedAt(LocalDateTime.now());
+    }
 }

--- a/src/main/java/com/conk/integration/command/domain/aggregate/ChannelOrderItem.java
+++ b/src/main/java/com/conk/integration/command/domain/aggregate/ChannelOrderItem.java
@@ -5,6 +5,8 @@ import com.conk.integration.command.domain.aggregate.embeddable.ChannelOrderItem
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 // 주문에 속한 SKU 단위 수량/작업 상태를 저장하는 자식 엔티티다.
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,4 +37,20 @@ public class ChannelOrderItem {
     @Embedded
     @Builder.Default
     private AuditFields audit = new AuditFields();
+
+    public void updateProductNameSnapshot(String productNameSnapshot) {
+        this.productNameSnapshot = productNameSnapshot;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        audit.setCreatedAt(now);
+        audit.setUpdatedAt(now);
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        audit.setUpdatedAt(LocalDateTime.now());
+    }
 }

--- a/src/main/java/com/conk/integration/command/infrastructure/config/ShopifyProperties.java
+++ b/src/main/java/com/conk/integration/command/infrastructure/config/ShopifyProperties.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.regex.Pattern;
+
 // Shopify API 버전과 URL 조합 유틸리티를 제공한다.
 // storeName과 accessToken은 ChannelApi 테이블에서 sellerId 기준으로 동적으로 조회한다.
 @ConfigurationProperties(prefix = "shopify")
@@ -11,11 +13,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Setter
 public class ShopifyProperties {
 
+    private static final Pattern SHOPIFY_STORE_PATTERN =
+            Pattern.compile("^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$");
+
     private String apiVersion = "2025-01";
 
     // 스토어 단위 기본 URL.
     public String getBaseUrl(String storeName) {
-        return "https://" + storeName + ".myshopify.com";
+        return "https://" + normalizeStoreName(storeName) + ".myshopify.com";
     }
 
     // GraphQL Admin API 엔드포인트.
@@ -26,5 +31,13 @@ public class ShopifyProperties {
     // 주문별 fulfillment 생성 엔드포인트.
     public String getFulfillmentsUrl(String storeName, String shopifyOrderId) {
         return getBaseUrl(storeName) + "/admin/api/" + apiVersion + "/orders/" + shopifyOrderId + "/fulfillments.json";
+    }
+
+    private String normalizeStoreName(String storeName) {
+        String normalized = storeName == null ? "" : storeName.trim().toLowerCase();
+        if (!SHOPIFY_STORE_PATTERN.matcher(normalized).matches()) {
+            throw new IllegalArgumentException("유효하지 않은 Shopify storeName 형식입니다: " + storeName);
+        }
+        return normalized;
     }
 }

--- a/src/test/java/com/conk/integration/command/application/controller/IntegrationCommandControllerTest.java
+++ b/src/test/java/com/conk/integration/command/application/controller/IntegrationCommandControllerTest.java
@@ -2,6 +2,8 @@ package com.conk.integration.command.application.controller;
 
 import com.conk.integration.command.application.controller.IntegrationCommandController;
 import java.util.List;
+import com.conk.integration.command.application.service.SellerChannelConnectService;
+import com.conk.integration.command.application.dto.response.BulkFulfillmentResponse;
 import com.conk.integration.command.application.dto.response.BulkInvoiceResponse;
 import com.conk.integration.command.application.dto.response.ChannelOrderSyncResponse;
 import com.conk.integration.command.application.dto.response.ManualOrderInvoiceResponse;
@@ -14,6 +16,7 @@ import com.conk.integration.command.domain.aggregate.enums.CarrierType;
 import com.conk.integration.common.exception.BusinessException;
 import com.conk.integration.common.exception.ErrorCode;
 import com.conk.integration.common.exception.GlobalExceptionHandler;
+import com.conk.integration.query.dto.SellerChannelDetailDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 // fulfillment command API의 웹 계약을 슬라이스 테스트로 고정한다.
 @WebMvcTest(IntegrationCommandController.class)
 @Import(GlobalExceptionHandler.class)
-@DisplayName("[Controller] IntegrationCommandController 슬라이스 테스트")
+@DisplayName("IntegrationCommandController 테스트")
 class IntegrationCommandControllerTest {
 
     @Autowired
@@ -56,12 +59,121 @@ class IntegrationCommandControllerTest {
     @MockitoBean
     private ManualOrderInvoiceService manualOrderInvoiceService;
 
+    @MockitoBean
+    private SellerChannelConnectService sellerChannelConnectService;
+
     @Nested
-    @DisplayName("POST /integrations/seller/orders/fulfillment/{orderId} — fulfillment 생성 (INT-003)")
+    @DisplayName("셀러 채널 연결 테스트")
+    class ConnectSellerChannelTests {
+
+        private static final String REQUEST_BODY = """
+                {
+                  "storeName": "my-shopify-store",
+                  "channelApi": "shpat_test_token",
+                  "storeAlias": "Shopify KR Store",
+                  "contactEmail": "ops@example.com",
+                  "syncMode": "AUTO"
+                }
+                """;
+
+        @Test
+        @DisplayName("유효한 판매자 헤더와 Shopify 연결 요청이 주어지면 채널 연결을 요청했을 때 HTTP 200 응답과 연결 정보를 반환해야 한다")
+        void connectSellerChannel_returnsOk() throws Exception {
+            SellerChannelDetailDto response = new SellerChannelDetailDto(
+                    "SHOPIFY",
+                    "my-shopify-store",
+                    "shpat_test_token",
+                    java.time.LocalDateTime.of(2026, 4, 10, 10, 30));
+            given(sellerChannelConnectService.connect(anyString(), anyString(), any())).willReturn(response);
+
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/connect", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-001")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(REQUEST_BODY))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.channelName").value("SHOPIFY"))
+                    .andExpect(jsonPath("$.data.storeName").value("my-shopify-store"))
+                    .andExpect(jsonPath("$.data.channelApi").value("shpat_test_token"));
+        }
+
+        @Test
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 채널 연결을 요청했을 때 HTTP 400 응답을 반환해야 한다")
+        void connectSellerChannel_missingSellerIdHeader_returns400() throws Exception {
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/connect", "SHOPIFY")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(REQUEST_BODY))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.message").value("필수 헤더가 누락되었습니다: X-Seller-Id"));
+        }
+
+        @Test
+        @DisplayName("지원하지 않는 채널 키가 주어지면 채널 연결을 요청했을 때 HTTP 400 응답을 반환해야 한다")
+        void connectSellerChannel_unsupportedChannel_returns400() throws Exception {
+            given(sellerChannelConnectService.connect(anyString(), anyString(), any()))
+                    .willThrow(new BusinessException(ErrorCode.UNSUPPORTED_CHANNEL,
+                            "지원하지 않는 채널 연결 채널입니다: AMAZON"));
+
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/connect", "AMAZON")
+                            .header("X-Seller-Id", "seller-001")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(REQUEST_BODY))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.code").value("INT-004"))
+                    .andExpect(jsonPath("$.message").value("지원하지 않는 채널 연결 채널입니다: AMAZON"));
+        }
+
+        @Test
+        @DisplayName("storeName이 없는 요청이 주어지면 채널 연결을 요청했을 때 HTTP 400 응답을 반환해야 한다")
+        void connectSellerChannel_missingStoreName_returns400() throws Exception {
+            given(sellerChannelConnectService.connect(anyString(), anyString(), any()))
+                    .willThrow(new BusinessException(ErrorCode.INVALID_SELLER_ID, "storeName는 필수입니다."));
+
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/connect", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-001")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"storeName":" ","channelApi":"shpat_test_token"}
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.message").value("storeName는 필수입니다."));
+        }
+
+        @Test
+        @DisplayName("Shopify 연결 검증에 실패하면 채널 연결을 요청했을 때 HTTP 404 응답을 반환해야 한다")
+        void connectSellerChannel_pingFail_returns404() throws Exception {
+            given(sellerChannelConnectService.connect(anyString(), anyString(), any()))
+                    .willThrow(new BusinessException(ErrorCode.CHANNEL_CONNECTION_NOT_FOUND,
+                            "Shopify 채널 연결에 실패했습니다."));
+
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/connect", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-001")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(REQUEST_BODY))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.code").value("INT-404"))
+                    .andExpect(jsonPath("$.message").value("Shopify 채널 연결에 실패했습니다."));
+        }
+
+        @Test
+        @DisplayName("GET 메서드로 채널 연결을 요청했을 때 HTTP 405 응답을 반환해야 한다")
+        void connectSellerChannel_wrongMethod_returns405() throws Exception {
+            mockMvc.perform(get("/integrations/seller/channels/{channelKey}/connect", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-001"))
+                    .andExpect(status().isMethodNotAllowed());
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 fulfillment 생성 테스트")
     class CreateSellerOrderFulfillmentTests {
 
         @Test
-        @DisplayName("정상 요청 — HTTP 200과 success:true, data:null 이 반환된다")
+        @DisplayName("유효한 주문 번호가 주어지면 fulfillment 생성을 요청했을 때 HTTP 200 응답을 반환해야 한다")
         void createSellerOrderFulfillment_returnsOk() throws Exception {
             mockMvc.perform(post("/integrations/seller/orders/fulfillment/{orderId}", "ORD-20260330-0001"))
                     .andExpect(status().isOk())
@@ -74,7 +186,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("주문이 없으면 HTTP 404가 반환된다")
+        @DisplayName("존재하지 않는 주문 번호가 주어지면 fulfillment 생성을 요청했을 때 HTTP 404 응답을 반환해야 한다")
         void createSellerOrderFulfillment_orderNotFound_returns404() throws Exception {
             doThrow(new BusinessException(ErrorCode.ORDER_NOT_FOUND, "주문을 찾을 수 없습니다: ORD-404"))
                     .when(fulfillmentDispatchService)
@@ -88,7 +200,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("송장 미발급 주문이면 HTTP 409가 반환된다")
+        @DisplayName("송장이 발급되지 않은 주문 번호가 주어지면 fulfillment 생성을 요청했을 때 HTTP 409 응답을 반환해야 한다")
         void createSellerOrderFulfillment_orderNotInvoiced_returns409() throws Exception {
             doThrow(new BusinessException(ErrorCode.ORDER_NOT_INVOICED, "송장이 발급되지 않은 주문입니다: ORD-20260330-0001"))
                     .when(fulfillmentDispatchService)
@@ -102,7 +214,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("POST 외 메서드로 호출하면 HTTP 405가 반환된다")
+        @DisplayName("GET 메서드로 fulfillment 생성을 요청했을 때 HTTP 405 응답을 반환해야 한다")
         void createSellerOrderFulfillment_wrongMethod_returns405() throws Exception {
             mockMvc.perform(get("/integrations/seller/orders/fulfillment/{orderId}", "ORD-20260330-0001"))
                     .andExpect(status().isMethodNotAllowed());
@@ -110,7 +222,7 @@ class IntegrationCommandControllerTest {
     }
 
     @Nested
-    @DisplayName("POST /integrations/seller/orders/invoice — EasyPost 단건 송장 발급 (INT-005)")
+    @DisplayName("단건 송장 발급 테스트")
     class CreateShipmentInvoiceTests {
 
         private static final String REQUEST_BODY = """
@@ -118,7 +230,7 @@ class IntegrationCommandControllerTest {
                 """;
 
         @Test
-        @DisplayName("정상 요청 — HTTP 200과 success:true, data(송장 정보)가 반환된다")
+        @DisplayName("유효한 송장 발급 요청이 주어지면 단건 송장 발급을 요청했을 때 HTTP 200 응답과 송장 정보를 반환해야 한다")
         void createShipmentInvoice_returnsOk() throws Exception {
             EasypostShipmentInvoice invoice = EasypostShipmentInvoice.builder()
                     .invoiceNo("shp_test_001")
@@ -144,7 +256,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("운임 정보가 없으면 HTTP 404가 반환된다")
+        @DisplayName("운임 정보가 없는 요청이 주어지면 단건 송장 발급을 요청했을 때 HTTP 404 응답을 반환해야 한다")
         void createShipmentInvoice_noRates_returns404() throws Exception {
             given(easyPostInvoiceSaveService.createAndSaveInvoice(any()))
                     .willThrow(new BusinessException(ErrorCode.NO_SHIPPING_RATES));
@@ -159,7 +271,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("POST 외 메서드로 호출하면 HTTP 405가 반환된다")
+        @DisplayName("GET 메서드로 단건 송장 발급을 요청했을 때 HTTP 405 응답을 반환해야 한다")
         void createShipmentInvoice_wrongMethod_returns405() throws Exception {
             mockMvc.perform(get("/integrations/seller/orders/invoice"))
                     .andExpect(status().isMethodNotAllowed());
@@ -167,7 +279,7 @@ class IntegrationCommandControllerTest {
     }
 
     @Nested
-    @DisplayName("POST /integrations/seller/orders/bulk-invoice — EasyPost 일괄 송장 발급 (INT-006)")
+    @DisplayName("일괄 송장 발급 테스트")
     class CreateBulkShipmentInvoiceTests {
 
         private static final String REQUEST_BODY = """
@@ -175,7 +287,7 @@ class IntegrationCommandControllerTest {
                 """;
 
         @Test
-        @DisplayName("정상 요청 — HTTP 200과 success:true, data(successCount/failCount)가 반환된다")
+        @DisplayName("유효한 일괄 송장 발급 요청이 주어지면 일괄 송장 발급을 요청했을 때 HTTP 200 응답과 처리 건수를 반환해야 한다")
         void createBulkShipmentInvoice_returnsOk() throws Exception {
             given(easyPostInvoiceSaveService.createAndSaveBulkInvoices(any(), any(), any()))
                     .willReturn(new BulkInvoiceResponse(2, 0));
@@ -190,7 +302,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("예기치 못한 서버 오류는 HTTP 500이 반환된다")
+        @DisplayName("내부 서버 오류가 발생하면 일괄 송장 발급을 요청했을 때 HTTP 500 응답을 반환해야 한다")
         void createBulkShipmentInvoice_unexpectedError_returns500() throws Exception {
             given(easyPostInvoiceSaveService.createAndSaveBulkInvoices(any(), any(), any()))
                     .willThrow(new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "DB 연결 오류"));
@@ -205,7 +317,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("POST 외 메서드로 호출하면 HTTP 405가 반환된다")
+        @DisplayName("GET 메서드로 일괄 송장 발급을 요청했을 때 HTTP 405 응답을 반환해야 한다")
         void createBulkShipmentInvoice_wrongMethod_returns405() throws Exception {
             mockMvc.perform(get("/integrations/seller/orders/bulk-invoice"))
                     .andExpect(status().isMethodNotAllowed());
@@ -213,7 +325,81 @@ class IntegrationCommandControllerTest {
     }
 
     @Nested
-    @DisplayName("POST /integrations/seller/orders/sync — 채널 주문 동기화 (INT-007)")
+    @DisplayName("일괄 fulfillment 전송 테스트")
+    class CreateBulkFulfillmentTests {
+
+        private static final String REQUEST_BODY = """
+                {"orderChannel":"SHOPIFY"}
+                """;
+
+        @Test
+        @DisplayName("유효한 판매자 헤더와 채널 정보가 주어지면 일괄 fulfillment 전송을 요청했을 때 HTTP 200 응답과 처리 건수를 반환해야 한다")
+        void createBulkFulfillment_returnsOk() throws Exception {
+            given(fulfillmentDispatchService.fulfillBulk(anyString(), any()))
+                    .willReturn(new BulkFulfillmentResponse(2, 1));
+
+            mockMvc.perform(post("/integrations/seller/orders/bulk-fulfillment")
+                            .header("X-Seller-Id", "seller-001")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(REQUEST_BODY))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.successCount").value(2))
+                    .andExpect(jsonPath("$.data.failCount").value(1));
+        }
+
+        @Test
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 일괄 fulfillment 전송을 요청했을 때 HTTP 400 응답을 반환해야 한다")
+        void createBulkFulfillment_missingSellerIdHeader_returns400() throws Exception {
+            mockMvc.perform(post("/integrations/seller/orders/bulk-fulfillment")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(REQUEST_BODY))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.message").value("필수 헤더가 누락되었습니다: X-Seller-Id"));
+        }
+
+        @Test
+        @DisplayName("지원하지 않는 채널 정보가 주어지면 일괄 fulfillment 전송을 요청했을 때 HTTP 400 응답을 반환해야 한다")
+        void createBulkFulfillment_unsupportedChannel_returns400() throws Exception {
+            given(fulfillmentDispatchService.fulfillBulk(anyString(), any()))
+                    .willThrow(new BusinessException(ErrorCode.UNSUPPORTED_CHANNEL, "지원하지 않는 fulfillment 채널입니다."));
+
+            mockMvc.perform(post("/integrations/seller/orders/bulk-fulfillment")
+                            .header("X-Seller-Id", "seller-001")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(REQUEST_BODY))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.code").value("INT-004"))
+                    .andExpect(jsonPath("$.message").value("지원하지 않는 fulfillment 채널입니다."));
+        }
+
+        @Test
+        @DisplayName("서비스에서 예기치 않은 예외가 발생하면 일괄 fulfillment 전송을 요청했을 때 HTTP 500 응답을 반환해야 한다")
+        void createBulkFulfillment_serviceThrows_returns500() throws Exception {
+            given(fulfillmentDispatchService.fulfillBulk(anyString(), any()))
+                    .willThrow(new RuntimeException("예상치 못한 서버 오류"));
+
+            mockMvc.perform(post("/integrations/seller/orders/bulk-fulfillment")
+                            .header("X-Seller-Id", "seller-001")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(REQUEST_BODY))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("GET 메서드로 일괄 fulfillment 전송을 요청했을 때 HTTP 405 응답을 반환해야 한다")
+        void createBulkFulfillment_wrongMethod_returns405() throws Exception {
+            mockMvc.perform(get("/integrations/seller/orders/bulk-fulfillment")
+                            .header("X-Seller-Id", "seller-001"))
+                    .andExpect(status().isMethodNotAllowed());
+        }
+    }
+
+    @Nested
+    @DisplayName("채널 주문 동기화 테스트")
     class SyncChannelOrdersTests {
 
         private static final String REQUEST_BODY = """
@@ -221,7 +407,7 @@ class IntegrationCommandControllerTest {
                 """;
 
         @Test
-        @DisplayName("정상 요청 — HTTP 200과 success:true, data(savedCount/skippedCount)가 반환된다")
+        @DisplayName("유효한 판매자 헤더와 채널 정보가 주어지면 채널 주문 동기화를 요청했을 때 HTTP 200 응답과 저장 결과를 반환해야 한다")
         void syncChannelOrders_validRequest_returns200() throws Exception {
             ChannelOrderSyncResponse response = new ChannelOrderSyncResponse(3, 1, List.of());
             given(orderSyncDispatchService.sync(any(), any())).willReturn(response);
@@ -237,7 +423,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("X-Seller-Id 헤더가 없으면 HTTP 400이 반환된다")
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 채널 주문 동기화를 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void syncChannelOrders_missingSellerIdHeader_returns400() throws Exception {
             mockMvc.perform(post("/integrations/seller/orders/sync")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -248,7 +434,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("Service가 BusinessException(INT-004)을 던지면 HTTP 400이 반환된다")
+        @DisplayName("서비스에서 BusinessException(INT-004)이 발생하면 채널 주문 동기화를 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void syncChannelOrders_serviceThrows_returns400() throws Exception {
             given(orderSyncDispatchService.sync(any(), any()))
                     .willThrow(new BusinessException(ErrorCode.UNSUPPORTED_CHANNEL, "지원하지 않는 채널"));
@@ -264,20 +450,62 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("POST 외 메서드로 호출하면 HTTP 405가 반환된다")
+        @DisplayName("GET 메서드로 채널 주문 동기화를 요청했을 때 HTTP 405 응답을 반환해야 한다")
         void syncChannelOrders_wrongMethod_returns405() throws Exception {
             mockMvc.perform(get("/integrations/seller/orders/sync")
+                            .header("X-Seller-Id", "seller-001"))
+                    .andExpect(status().isMethodNotAllowed());
+        }
+
+        @Test
+        @DisplayName("유효한 판매자 헤더와 채널 키가 주어지면 채널 기준 주문 동기화를 요청했을 때 HTTP 200 응답과 저장 결과를 반환해야 한다")
+        void syncChannelOrdersByChannel_validRequest_returns200() throws Exception {
+            ChannelOrderSyncResponse response = new ChannelOrderSyncResponse(2, 1, List.of());
+            given(orderSyncDispatchService.sync(any(), any())).willReturn(response);
+
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/sync", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-001"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.savedCount").value(2))
+                    .andExpect(jsonPath("$.data.skippedCount").value(1));
+        }
+
+        @Test
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 채널 기준 주문 동기화를 요청했을 때 HTTP 400 응답을 반환해야 한다")
+        void syncChannelOrdersByChannel_missingSellerIdHeader_returns400() throws Exception {
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/sync", "SHOPIFY"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.message").value("필수 헤더가 누락되었습니다: X-Seller-Id"));
+        }
+
+        @Test
+        @DisplayName("지원하지 않는 채널 키가 주어지면 채널 기준 주문 동기화를 요청했을 때 HTTP 400 응답을 반환해야 한다")
+        void syncChannelOrdersByChannel_unsupportedChannel_returns400() throws Exception {
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/sync", "UNKNOWN")
+                            .header("X-Seller-Id", "seller-001"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.code").value("INT-004"))
+                    .andExpect(jsonPath("$.message").value("지원하지 않는 주문 동기화 채널입니다: UNKNOWN"));
+        }
+
+        @Test
+        @DisplayName("GET 메서드로 채널 기준 주문 동기화를 요청했을 때 HTTP 405 응답을 반환해야 한다")
+        void syncChannelOrdersByChannel_wrongMethod_returns405() throws Exception {
+            mockMvc.perform(get("/integrations/seller/channels/{channelKey}/sync", "SHOPIFY")
                             .header("X-Seller-Id", "seller-001"))
                     .andExpect(status().isMethodNotAllowed());
         }
     }
 
     @Nested
-    @DisplayName("POST /integrations/seller/channels/{channelKey}/import-orders — 채널 주문 가져오기")
+    @DisplayName("채널 주문 가져오기 테스트")
     class ImportChannelOrdersTests {
 
         @Test
-        @DisplayName("정상 요청 — body 없이 호출해도 importedCount/skippedCount가 반환된다")
+        @DisplayName("요청 본문이 없는 요청이 주어지면 채널 주문 가져오기를 요청했을 때 HTTP 200 응답과 처리 건수를 반환해야 한다")
         void importChannelOrders_withoutBody_returns200() throws Exception {
             ChannelOrderSyncResponse response = new ChannelOrderSyncResponse(10, 2, List.of());
             given(orderSyncDispatchService.sync(any(), any())).willReturn(response);
@@ -291,7 +519,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("정상 요청 — 빈 JSON body여도 importedCount/skippedCount가 반환된다")
+        @DisplayName("빈 JSON 본문이 주어지면 채널 주문 가져오기를 요청했을 때 HTTP 200 응답과 처리 건수를 반환해야 한다")
         void importChannelOrders_emptyJsonBody_returns200() throws Exception {
             ChannelOrderSyncResponse response = new ChannelOrderSyncResponse(3, 1, List.of());
             given(orderSyncDispatchService.sync(any(), any())).willReturn(response);
@@ -307,7 +535,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("X-Seller-Id 헤더가 없으면 HTTP 400이 반환된다")
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 채널 주문 가져오기를 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void importChannelOrders_missingSellerIdHeader_returns400() throws Exception {
             mockMvc.perform(post("/integrations/seller/channels/{channelKey}/import-orders", "SHOPIFY"))
                     .andExpect(status().isBadRequest())
@@ -316,7 +544,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("지원하지 않는 channelKey면 HTTP 400이 반환된다")
+        @DisplayName("지원하지 않는 채널 키가 주어지면 채널 주문 가져오기를 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void importChannelOrders_unsupportedChannel_returns400() throws Exception {
             mockMvc.perform(post("/integrations/seller/channels/{channelKey}/import-orders", "UNKNOWN")
                             .header("X-Seller-Id", "seller-001"))
@@ -327,7 +555,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("Service가 지원 불가 예외를 던지면 HTTP 400이 반환된다")
+        @DisplayName("서비스에서 지원하지 않는 채널 예외가 발생하면 채널 주문 가져오기를 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void importChannelOrders_serviceThrows_returns400() throws Exception {
             given(orderSyncDispatchService.sync(any(), any()))
                     .willThrow(new BusinessException(ErrorCode.UNSUPPORTED_CHANNEL, "지원하지 않는 주문 동기화 채널입니다: SHOPIFY"));
@@ -339,10 +567,18 @@ class IntegrationCommandControllerTest {
                     .andExpect(jsonPath("$.code").value("INT-004"))
                     .andExpect(jsonPath("$.message").value("지원하지 않는 주문 동기화 채널입니다: SHOPIFY"));
         }
+
+        @Test
+        @DisplayName("GET 메서드로 채널 주문 가져오기를 요청했을 때 HTTP 405 응답을 반환해야 한다")
+        void importChannelOrders_wrongMethod_returns405() throws Exception {
+            mockMvc.perform(get("/integrations/seller/channels/{channelKey}/import-orders", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-001"))
+                    .andExpect(status().isMethodNotAllowed());
+        }
     }
 
     @Nested
-    @DisplayName("POST /integrations/seller/orders/manual-invoice — 수동 주문 기입 및 송장 발급 (INT-008)")
+    @DisplayName("수동 주문 송장 발급 테스트")
     class CreateManualOrderInvoiceTests {
 
         private static final String REQUEST_BODY = """
@@ -362,7 +598,7 @@ class IntegrationCommandControllerTest {
                 """;
 
         @Test
-        @DisplayName("정상 요청 — HTTP 200과 success:true, data(주문+송장 정보)가 반환된다")
+        @DisplayName("유효한 수동 주문 요청이 주어지면 수동 주문 송장 발급을 요청했을 때 HTTP 200 응답과 주문 및 송장 정보를 반환해야 한다")
         void createManualOrderInvoice_returnsOk() throws Exception {
             List<ManualOrderInvoiceResponse.OrderItemBody> items =
                     List.of(new ManualOrderInvoiceResponse.OrderItemBody("SKU-001", "상품명", 2));
@@ -387,7 +623,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("X-Seller-Id 헤더가 없으면 HTTP 400이 반환된다")
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 수동 주문 송장 발급을 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void createManualOrderInvoice_missingSellerIdHeader_returns400() throws Exception {
             mockMvc.perform(post("/integrations/seller/orders/manual-invoice")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -398,7 +634,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("이미 송장이 발급된 주문 재요청 → HTTP 409이 반환된다")
+        @DisplayName("이미 송장이 발급된 주문 정보가 주어지면 수동 주문 송장 발급을 요청했을 때 HTTP 409 응답을 반환해야 한다")
         void createManualOrderInvoice_alreadyInvoiced_returns409() throws Exception {
             given(manualOrderInvoiceService.issue(anyString(), any()))
                     .willThrow(new BusinessException(ErrorCode.INVOICE_ALREADY_EXISTS, "이미 송장이 발급된 주문입니다: ORD-MANUAL-001"));
@@ -414,7 +650,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("EasyPost 운임 정보 없음 → HTTP 404이 반환된다")
+        @DisplayName("운임 정보가 없는 요청이 주어지면 수동 주문 송장 발급을 요청했을 때 HTTP 404 응답을 반환해야 한다")
         void createManualOrderInvoice_easyPostFails_returns404() throws Exception {
             given(manualOrderInvoiceService.issue(anyString(), any()))
                     .willThrow(new BusinessException(ErrorCode.NO_SHIPPING_RATES));
@@ -430,7 +666,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("POST 외 메서드로 호출하면 HTTP 405가 반환된다")
+        @DisplayName("GET 메서드로 수동 주문 송장 발급을 요청했을 때 HTTP 405 응답을 반환해야 한다")
         void createManualOrderInvoice_wrongMethod_returns405() throws Exception {
             mockMvc.perform(get("/integrations/seller/orders/manual-invoice")
                             .header("X-Seller-Id", "seller-001"))
@@ -438,7 +674,7 @@ class IntegrationCommandControllerTest {
         }
 
         @Test
-        @DisplayName("Service에서 예상치 못한 RuntimeException 발생 시 HTTP 500이 반환된다")
+        @DisplayName("서비스에서 예기치 않은 예외가 발생하면 수동 주문 송장 발급을 요청했을 때 HTTP 500 응답을 반환해야 한다")
         void createManualOrderInvoice_unexpectedError_returns500() throws Exception {
             given(manualOrderInvoiceService.issue(anyString(), any()))
                     .willThrow(new RuntimeException("예상치 못한 서버 오류"));

--- a/src/test/java/com/conk/integration/command/application/dto/response/ManualOrderInvoiceResponseTest.java
+++ b/src/test/java/com/conk/integration/command/application/dto/response/ManualOrderInvoiceResponseTest.java
@@ -1,0 +1,106 @@
+package com.conk.integration.command.application.dto.response;
+
+import com.conk.integration.command.domain.aggregate.ChannelOrder;
+import com.conk.integration.command.domain.aggregate.ChannelOrderItem;
+import com.conk.integration.command.domain.aggregate.EasypostShipmentInvoice;
+import com.conk.integration.command.domain.aggregate.embeddable.ChannelOrderItemId;
+import com.conk.integration.command.domain.aggregate.enums.CarrierType;
+import com.conk.integration.command.domain.aggregate.enums.OrderChannel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ManualOrderInvoiceResponse 테스트")
+class ManualOrderInvoiceResponseTest {
+
+    @Test
+    @DisplayName("주문과 송장 정보가 주어지면 응답 객체로 변환했을 때 주요 필드를 정확히 매핑해야 한다")
+    void of_mapsOrderAndInvoiceFieldsCorrectly() {
+        ChannelOrder order = buildOrder();
+        order.addItem(buildItem(order, "SKU-001", "상품 A", 2));
+        EasypostShipmentInvoice invoice = buildInvoice();
+
+        ManualOrderInvoiceResponse response = ManualOrderInvoiceResponse.of(order, invoice);
+
+        assertThat(response.getOrderId()).isEqualTo("ORD-001");
+        assertThat(response.getReceiverName()).isEqualTo("홍길동");
+        assertThat(response.getInvoiceNo()).isEqualTo("INV-001");
+        assertThat(response.getTrackingCode()).isEqualTo("TRK-001");
+        assertThat(response.getCarrierType()).isEqualTo("USPS");
+        assertThat(response.getFreightChargeAmt()).isEqualTo(550);
+        assertThat(response.getTrackingUrl()).isEqualTo("https://track.easypost.com/TRK-001");
+        assertThat(response.getLabelFileUrl()).isEqualTo("https://label.url/INV-001.pdf");
+    }
+
+    @Test
+    @DisplayName("빈 주소 조각이 포함된 주문 정보가 주어지면 응답 객체로 변환했을 때 배송지 주소를 조합해 반환해야 한다")
+    void of_buildsShipToAddressWithoutBlankParts() {
+        ChannelOrder order = ChannelOrder.builder()
+                .orderId("ORD-001")
+                .orderChannel(OrderChannel.MANUAL)
+                .sellerId("seller-001")
+                .receiverName("홍길동")
+                .shipToAddress1("123 Main St")
+                .shipToAddress2("")
+                .shipToCity("Los Angeles")
+                .shipToState("CA")
+                .shipToZipCode("90001")
+                .build();
+        EasypostShipmentInvoice invoice = buildInvoice();
+
+        ManualOrderInvoiceResponse response = ManualOrderInvoiceResponse.of(order, invoice);
+
+        assertThat(response.getShipToAddress()).isEqualTo("123 Main St, Los Angeles, CA, 90001");
+    }
+
+    @Test
+    @DisplayName("주문 아이템이 포함된 주문 정보가 주어지면 응답 객체로 변환했을 때 주문 아이템 목록으로 변환해야 한다")
+    void of_mapsItemsToOrderItemBodies() {
+        ChannelOrder order = buildOrder();
+        order.addItem(buildItem(order, "SKU-001", "상품 A", 2));
+        order.addItem(buildItem(order, "SKU-002", "상품 B", 1));
+
+        ManualOrderInvoiceResponse response = ManualOrderInvoiceResponse.of(order, buildInvoice());
+
+        assertThat(response.getItems()).hasSize(2);
+        assertThat(response.getItems())
+                .extracting(ManualOrderInvoiceResponse.OrderItemBody::getSkuId)
+                .containsExactly("SKU-001", "SKU-002");
+    }
+
+    private ChannelOrder buildOrder() {
+        return ChannelOrder.builder()
+                .orderId("ORD-001")
+                .orderChannel(OrderChannel.MANUAL)
+                .sellerId("seller-001")
+                .receiverName("홍길동")
+                .shipToAddress1("123 Main St")
+                .shipToState("CA")
+                .shipToCity("Los Angeles")
+                .shipToZipCode("90001")
+                .build();
+    }
+
+    private ChannelOrderItem buildItem(ChannelOrder order, String skuId, String productName, int quantity) {
+        return ChannelOrderItem.builder()
+                .id(new ChannelOrderItemId(order.getOrderId(), skuId))
+                .channelOrder(order)
+                .productNameSnapshot(productName)
+                .quantity(quantity)
+                .build();
+    }
+
+    private EasypostShipmentInvoice buildInvoice() {
+        return EasypostShipmentInvoice.builder()
+                .invoiceNo("INV-001")
+                .trackingCode("TRK-001")
+                .carrierType(CarrierType.USPS)
+                .freightChargeAmt(550)
+                .trackingUrl("https://track.easypost.com/TRK-001")
+                .labelFileUrl("https://label.url/INV-001.pdf")
+                .build();
+    }
+}

--- a/src/test/java/com/conk/integration/command/application/service/ChannelFulfillmentDispatchServiceTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/ChannelFulfillmentDispatchServiceTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.mock;
 
 // fulfillment orchestration이 채널별 sender 선택과 예외 처리를 올바르게 수행하는지 본다.
 @ExtendWith(MockitoExtension.class)
-@DisplayName("ChannelFulfillmentDispatchService 단위 테스트")
+@DisplayName("ChannelFulfillmentDispatchService 테스트")
 class ChannelFulfillmentDispatchServiceTest {
 
     @Mock private ChannelOrderRepository channelOrderRepository;
@@ -54,7 +54,7 @@ class ChannelFulfillmentDispatchServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] SHOPIFY 주문이면 지원 sender를 선택해 send()를 호출한다")
+    @DisplayName("Shopify 주문과 송장 정보가 주어지면 fulfillment를 수행했을 때 지원 sender를 호출해야 한다")
     void fulfill_callsMatchedSender() {
         ChannelOrder order = ChannelOrder.builder()
                 .orderId("ORD-001")
@@ -76,7 +76,7 @@ class ChannelFulfillmentDispatchServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] 주문이 없으면 BusinessException(INT-101)")
+    @DisplayName("존재하지 않는 주문 번호가 주어지면 fulfillment를 수행했을 때 BusinessException(INT-101)을 발생시켜야 한다")
     void fulfill_throwsWhenOrderNotFound() {
         given(channelOrderRepository.findById("NOT_EXIST")).willReturn(Optional.empty());
 
@@ -86,7 +86,7 @@ class ChannelFulfillmentDispatchServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] invoiceNo가 없으면 BusinessException(INT-202)")
+    @DisplayName("송장 번호가 없는 주문이 주어지면 fulfillment를 수행했을 때 BusinessException(INT-202)를 발생시켜야 한다")
     void fulfill_throwsWhenInvoiceNoIsNull() {
         ChannelOrder order = ChannelOrder.builder()
                 .orderId("ORD-002")
@@ -104,7 +104,7 @@ class ChannelFulfillmentDispatchServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] 송장 엔티티가 없으면 BusinessException(INT-102)")
+    @DisplayName("저장된 송장이 없는 주문이 주어지면 fulfillment를 수행했을 때 BusinessException(INT-102)를 발생시켜야 한다")
     void fulfill_throwsWhenInvoiceNotFound() {
         ChannelOrder order = ChannelOrder.builder()
                 .orderId("ORD-003")
@@ -121,7 +121,7 @@ class ChannelFulfillmentDispatchServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] 지원 sender가 없으면 BusinessException(INT-004)")
+    @DisplayName("지원하지 않는 채널의 주문이 주어지면 fulfillment를 수행했을 때 BusinessException(INT-004)를 발생시켜야 한다")
     void fulfill_throwsWhenSenderNotSupported() {
         ChannelOrder order = ChannelOrder.builder()
                 .orderId("ORD-004")
@@ -149,7 +149,7 @@ class ChannelFulfillmentDispatchServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] 미전송 대상이 없으면 successCount=0, failCount=0 반환")
+    @DisplayName("미전송 대상이 없으면 일괄 fulfillment를 수행했을 때 성공 건수와 실패 건수를 0으로 반환해야 한다")
     void fulfillBulk_returnsZero_whenNoUnsyncedTargets() {
         given(channelFulfillmentMapper.findUnsyncedTargets("seller-001", "SHOPIFY"))
                 .willReturn(List.of());
@@ -163,7 +163,7 @@ class ChannelFulfillmentDispatchServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 미전송 대상 존재 시 sendBulk 호출 후 markAllSynced 1회 호출")
+    @DisplayName("미전송 대상이 있으면 일괄 fulfillment를 수행했을 때 sendBulk를 호출하고 동기화 상태를 갱신해야 한다")
     void fulfillBulk_callsSendBulkAndMarksSynced() {
         List<FulfillmentTargetDto> targets = List.of(
                 buildTarget("ORD-A", "gid://shopify/FulfillmentOrder/1", "INV-A", "USPS"),
@@ -182,7 +182,7 @@ class ChannelFulfillmentDispatchServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] sendBulk 실패 시 markAllSynced를 호출하지 않는다")
+    @DisplayName("일괄 fulfillment 전송에 실패하면 일괄 fulfillment를 수행했을 때 동기화 상태를 갱신하지 않아야 한다")
     void fulfillBulk_doesNotMarkSynced_whenSendBulkThrows() {
         List<FulfillmentTargetDto> targets = List.of(
                 buildTarget("ORD-A", "gid://shopify/FulfillmentOrder/1", "INV-A", "USPS")
@@ -201,7 +201,7 @@ class ChannelFulfillmentDispatchServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] mapper 조회 중 예외 발생 시 호출자에게 전파된다")
+    @DisplayName("미전송 대상 조회 중 예외가 발생하면 일괄 fulfillment를 수행했을 때 호출자에게 예외를 전파해야 한다")
     void fulfillBulk_propagatesException_whenMapperThrows() {
         given(channelFulfillmentMapper.findUnsyncedTargets("seller-001", "SHOPIFY"))
                 .willThrow(new RuntimeException("DB 연결 오류"));
@@ -215,7 +215,7 @@ class ChannelFulfillmentDispatchServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] 지원 sender가 없으면 sendBulk를 호출하지 않고 BusinessException(INT-004) 예외 발생")
+    @DisplayName("지원하는 sender가 없으면 일괄 fulfillment를 수행했을 때 sendBulk를 호출하지 않고 BusinessException(INT-004)를 발생시켜야 한다")
     void fulfillBulk_throwsWhenNoSenderSupports() {
         List<FulfillmentTargetDto> targets = List.of(
                 buildTarget("ORD-A", "gid://shopify/FulfillmentOrder/1", "INV-A", "USPS")

--- a/src/test/java/com/conk/integration/command/application/service/ChannelFulfillmentSenderTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/ChannelFulfillmentSenderTest.java
@@ -1,0 +1,38 @@
+package com.conk.integration.command.application.service;
+
+import com.conk.integration.command.domain.aggregate.ChannelOrder;
+import com.conk.integration.command.domain.aggregate.EasypostShipmentInvoice;
+import com.conk.integration.command.domain.aggregate.enums.OrderChannel;
+import com.conk.integration.common.exception.BusinessException;
+import com.conk.integration.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ChannelFulfillmentSender 테스트")
+class ChannelFulfillmentSenderTest {
+
+    private final ChannelFulfillmentSender sender = new ChannelFulfillmentSender() {
+        @Override
+        public boolean supports(OrderChannel channel) {
+            return false;
+        }
+
+        @Override
+        public void send(ChannelOrder order, EasypostShipmentInvoice invoice) {
+            // no-op
+        }
+    };
+
+    @Test
+    @DisplayName("기본 구현으로 일괄 fulfillment를 수행하면 BusinessException(INT-003)을 발생시켜야 한다")
+    void sendBulk_defaultImplementation_throwsUnsupportedBulkFulfillment() {
+        assertThatThrownBy(() -> sender.sendBulk("seller-001", List.of()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.UNSUPPORTED_BULK_FULFILLMENT);
+    }
+}

--- a/src/test/java/com/conk/integration/command/application/service/ChannelOrderSyncDispatchServiceTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/ChannelOrderSyncDispatchServiceTest.java
@@ -1,0 +1,77 @@
+package com.conk.integration.command.application.service;
+
+import com.conk.integration.command.application.dto.response.ChannelOrderSyncResponse;
+import com.conk.integration.command.domain.aggregate.enums.OrderChannel;
+import com.conk.integration.common.exception.BusinessException;
+import com.conk.integration.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChannelOrderSyncDispatchService 테스트")
+class ChannelOrderSyncDispatchServiceTest {
+
+    @Mock
+    private ChannelOrderSyncer shopifySyncer;
+
+    @Mock
+    private ChannelOrderSyncer amazonSyncer;
+
+    @Test
+    @DisplayName("지원하는 채널이 주어지면 주문 동기화를 수행했을 때 해당 syncer를 호출해야 한다")
+    void sync_callsMatchedSyncer() {
+        ChannelOrderSyncDispatchService service =
+                new ChannelOrderSyncDispatchService(List.of(shopifySyncer, amazonSyncer));
+        ChannelOrderSyncResponse response = new ChannelOrderSyncResponse(1, 0, List.of());
+
+        given(shopifySyncer.supports(OrderChannel.SHOPIFY)).willReturn(true);
+        given(shopifySyncer.syncOrders("seller-001")).willReturn(response);
+
+        ChannelOrderSyncResponse result = service.sync("seller-001", OrderChannel.SHOPIFY);
+
+        assertThat(result.getSavedCount()).isEqualTo(1);
+        then(shopifySyncer).should().syncOrders("seller-001");
+        then(amazonSyncer).should(never()).syncOrders("seller-001");
+    }
+
+    @Test
+    @DisplayName("지원하는 syncer가 없으면 주문 동기화를 수행했을 때 BusinessException(INT-004)를 발생시켜야 한다")
+    void sync_throwsWhenSyncerNotSupported() {
+        ChannelOrderSyncDispatchService service =
+                new ChannelOrderSyncDispatchService(List.of(shopifySyncer, amazonSyncer));
+
+        given(shopifySyncer.supports(OrderChannel.AMAZON)).willReturn(false);
+        given(amazonSyncer.supports(OrderChannel.AMAZON)).willReturn(false);
+
+        assertThatThrownBy(() -> service.sync("seller-001", OrderChannel.AMAZON))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.UNSUPPORTED_CHANNEL);
+    }
+
+    @Test
+    @DisplayName("판매자 ID가 주어지면 주문 동기화를 수행했을 때 선택된 syncer에 판매자 ID를 그대로 전달해야 한다")
+    void sync_passesSellerIdToSelectedSyncer() {
+        ChannelOrderSyncDispatchService service =
+                new ChannelOrderSyncDispatchService(List.of(shopifySyncer));
+
+        given(shopifySyncer.supports(OrderChannel.SHOPIFY)).willReturn(true);
+        given(shopifySyncer.syncOrders("seller-xyz"))
+                .willReturn(new ChannelOrderSyncResponse(0, 0, List.of()));
+
+        service.sync("seller-xyz", OrderChannel.SHOPIFY);
+
+        then(shopifySyncer).should().syncOrders("seller-xyz");
+    }
+}

--- a/src/test/java/com/conk/integration/command/application/service/CommandApplicationServiceTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/CommandApplicationServiceTest.java
@@ -47,12 +47,12 @@ import static org.mockito.BDDMockito.willThrow;
  * - Repository / API 클라이언트를 @Mock으로 대체하여 Service 비즈니스 로직 자체에 집중
  */
 @ExtendWith(MockitoExtension.class)
-@DisplayName("[Service] Command Application Service 단위 테스트 (Mockito)")
+@DisplayName("CommandApplicationService 테스트")
 class CommandApplicationServiceTest {
 
     // Shopify 주문 동기화의 저장 분기만 빠르게 읽히도록 묶는다.
     @Nested
-    @DisplayName("ShopifyOrderSyncService")
+    @DisplayName("Shopify 주문 동기화 테스트")
     class ShopifyOrderSyncServiceTests {
 
         @Mock
@@ -68,7 +68,7 @@ class CommandApplicationServiceTest {
         private ShopifyOrderSyncService shopifyOrderSyncService;
 
         @Test
-        @DisplayName("syncOrders() — 신규 주문만 DB에 저장된다 (이미 존재하는 주문 skip)")
+        @DisplayName("신규 주문과 기존 주문이 함께 주어지면 주문 동기화를 수행했을 때 신규 주문만 저장해야 한다")
         void syncOrders_savesOnlyNewOrders() {
             // 1001은 중복, 1002만 신규로 취급되도록 fixture를 구성한다.
             ShopifyOrderResponse.OrderNode existingNode = buildOrderNode(1001L, "#1001");
@@ -85,7 +85,7 @@ class CommandApplicationServiceTest {
         }
 
         @Test
-        @DisplayName("syncOrders() — 모든 주문이 이미 존재하면 save()가 호출되지 않는다")
+        @DisplayName("모든 주문이 이미 저장되어 있으면 주문 동기화를 수행했을 때 주문을 저장하지 않아야 한다")
         void syncOrders_savesNothing_whenAllExist() {
             // 전체가 중복이면 저장 호출이 완전히 없어야 한다.
             given(channelApiQueryService.findShopifyCredential("seller-B")).willReturn(buildCredential());
@@ -99,7 +99,7 @@ class CommandApplicationServiceTest {
         }
 
         @Test
-        @DisplayName("syncOrders() — Shopify 주문 목록이 0건이면 save()가 호출되지 않는다")
+        @DisplayName("Shopify 주문 목록이 비어 있으면 주문 동기화를 수행했을 때 주문을 저장하지 않아야 한다")
         void syncOrders_savesNothing_whenEmptyOrders() {
             // 외부 API가 빈 목록을 주면 서비스는 조용히 종료해야 한다.
             given(channelApiQueryService.findShopifyCredential("seller-C")).willReturn(buildCredential());
@@ -128,7 +128,7 @@ class CommandApplicationServiceTest {
     }
 
     @Nested
-    @DisplayName("EasyPostInvoiceSaveService")
+    @DisplayName("EasyPost 송장 저장 테스트")
     class EasyPostInvoiceSaveServiceTests {
 
         @Mock
@@ -141,7 +141,7 @@ class CommandApplicationServiceTest {
         private EasyPostInvoiceSaveService easyPostInvoiceSaveService;
 
         @Test
-        @DisplayName("createAndSaveInvoice() — 최저가 rate 선택 후 shipment를 구매하고 DB에 저장한다")
+        @DisplayName("여러 운임 정보가 주어지면 송장을 생성하고 저장했을 때 최저가 운임으로 구매 후 저장해야 한다")
         void createAndSaveInvoice_buysLowestRateAndSaves() {
             // createShipment 응답은 정렬되지 않은 rate 목록으로 만들어 최저가 선택 로직을 같이 검증한다.
             EasyPostShipmentResponse.RateDto cheapRate = new EasyPostShipmentResponse.RateDto();
@@ -187,7 +187,7 @@ class CommandApplicationServiceTest {
         }
 
         @Test
-        @DisplayName("selectCheapestRate() — rates 목록 중 가장 낮은 금액의 rate를 반환한다")
+        @DisplayName("여러 운임 정보가 주어지면 최저 운임을 조회했을 때 가장 낮은 금액의 운임을 반환해야 한다")
         void selectCheapestRate_returnsLowestRate() {
             // helper 메서드는 호출 순서와 무관하게 최저 금액을 찾아야 한다.
             EasyPostShipmentResponse.RateDto r1 = rate("r1", "12.50");
@@ -202,7 +202,7 @@ class CommandApplicationServiceTest {
         }
 
         @Test
-        @DisplayName("selectCheapestRate() — rates가 비어있으면 BusinessException(INT-104)을 던진다")
+        @DisplayName("운임 정보가 비어 있으면 최저 운임을 조회했을 때 BusinessException(INT-104)를 발생시켜야 한다")
         void selectCheapestRate_throwsWhenEmpty() {
             // 송장 구매를 진행할 수 없는 입력은 빠르게 실패시킨다.
             assertThatThrownBy(() -> easyPostInvoiceSaveService.selectCheapestRate(List.of()))
@@ -211,7 +211,7 @@ class CommandApplicationServiceTest {
         }
 
         @Test
-        @DisplayName("selectCheapestRate() — rate가 null인 항목은 무시되고 유효한 최저가를 반환한다")
+        @DisplayName("일부 운임 금액이 null인 목록이 주어지면 최저 운임을 조회했을 때 유효한 최저가를 반환해야 한다")
         void selectCheapestRate_ignoresNullRates() {
             // 외부 API 일부 값이 비어 있어도 유효한 금액이 남아 있으면 계산 가능해야 한다.
             EasyPostShipmentResponse.RateDto rNull = new EasyPostShipmentResponse.RateDto();
@@ -226,7 +226,7 @@ class CommandApplicationServiceTest {
         }
 
         @Test
-        @DisplayName("fromEasyPostName() — carrier 문자열에 따라 올바른 CarrierType을 반환한다")
+        @DisplayName("운송사 이름이 주어지면 CarrierType으로 변환했을 때 올바른 값을 반환해야 한다")
         void fromEasyPostName_mapsCorrectly() {
             // 지원하지 않는 문자열은 기본 운송사로 안전하게 매핑한다.
             assertThat(CarrierType.fromEasyPostName("UPS")).isEqualTo(CarrierType.UPS);
@@ -246,7 +246,7 @@ class CommandApplicationServiceTest {
     }
 
     @Nested
-    @DisplayName("ChannelFulfillmentDispatchService")
+    @DisplayName("채널 fulfillment 분기 테스트")
     class ChannelFulfillmentDispatchServiceTests {
 
         @Mock
@@ -274,7 +274,7 @@ class CommandApplicationServiceTest {
         }
 
         @Test
-        @DisplayName("fulfill() — SHOPIFY 주문이면 지원 sender를 1회 호출한다")
+        @DisplayName("Shopify 주문과 송장 정보가 주어지면 fulfillment를 수행했을 때 지원 sender를 한 번 호출해야 한다")
         void fulfill_callsShopifyApi() {
             // dispatch는 공통 조회 후 채널 sender로 위임해야 한다.
             ChannelOrder order = ChannelOrder.builder()
@@ -300,7 +300,7 @@ class CommandApplicationServiceTest {
         }
 
         @Test
-        @DisplayName("fulfill() — 주문이 없으면 BusinessException(INT-101)을 던진다")
+        @DisplayName("존재하지 않는 주문 번호가 주어지면 fulfillment를 수행했을 때 BusinessException(INT-101)을 발생시켜야 한다")
         void fulfill_throwsWhenOrderNotFound() {
             // 주문 자체가 없으면 이후 출고 로직으로 진행하면 안 된다.
             given(channelOrderRepository.findById("O-NONE")).willReturn(Optional.empty());
@@ -311,7 +311,7 @@ class CommandApplicationServiceTest {
         }
 
         @Test
-        @DisplayName("fulfill() — invoiceNo가 null이면 BusinessException(INT-202)을 던진다")
+        @DisplayName("송장 번호가 없는 주문이 주어지면 fulfillment를 수행했을 때 BusinessException(INT-202)를 발생시켜야 한다")
         void fulfill_throwsWhenInvoiceNoIsNull() {
             // 송장 참조가 빠진 주문은 출고 API 호출 전 단계에서 막아야 한다.
             ChannelOrder order = ChannelOrder.builder()
@@ -330,7 +330,7 @@ class CommandApplicationServiceTest {
         }
 
         @Test
-        @DisplayName("fulfill() — invoice가 DB에 없으면 BusinessException(INT-102)을 던진다")
+        @DisplayName("저장된 송장이 없는 주문이 주어지면 fulfillment를 수행했을 때 BusinessException(INT-102)를 발생시켜야 한다")
         void fulfill_throwsWhenInvoiceNotInDb() {
             // 주문에는 참조가 있지만 실제 송장이 없을 때의 불일치 케이스다.
             ChannelOrder order = ChannelOrder.builder()
@@ -350,7 +350,7 @@ class CommandApplicationServiceTest {
         }
 
         @Test
-        @DisplayName("fulfill() — 지원 sender가 없으면 BusinessException(INT-004)을 던진다")
+        @DisplayName("지원하지 않는 채널의 주문이 주어지면 fulfillment를 수행했을 때 BusinessException(INT-004)를 발생시켜야 한다")
         void fulfill_throwsWhenSenderNotSupported() {
             ChannelOrder order = ChannelOrder.builder()
                     .orderId("O-004")

--- a/src/test/java/com/conk/integration/command/application/service/EasyPostInvoiceSaveServiceTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/EasyPostInvoiceSaveServiceTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.*;
 
 // EasyPost 송장 저장 서비스의 정상 흐름과 예외 전파를 Mockito로 검증한다.
 @ExtendWith(MockitoExtension.class)
-@DisplayName("EasyPostInvoiceSaveService 단위 테스트")
+@DisplayName("EasyPostInvoiceSaveService 테스트")
 class EasyPostInvoiceSaveServiceTest {
 
     @Mock private EasyPostApiClient easyPostApiClient;
@@ -51,7 +51,7 @@ class EasyPostInvoiceSaveServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] 정상 플로우 - createShipment → buyRate → DB 저장")
+    @DisplayName("유효한 운송장 요청이 주어지면 송장을 생성하고 저장했을 때 생성, 구매, 저장 순서로 처리해야 한다")
     void createAndSaveInvoice_fullHappyPath() {
         // 비싼/싼 운임을 함께 내려 최저가 선택과 저장을 한 번에 확인한다.
         EasyPostShipmentResponse created = buildShipmentWithRates("shp_001",
@@ -72,7 +72,7 @@ class EasyPostInvoiceSaveServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 최저가 rate가 올바르게 선택됨")
+    @DisplayName("여러 운임 정보가 주어지면 최저 운임을 선택했을 때 가장 저렴한 운임을 반환해야 한다")
     void selectCheapestRate_picksLowestRate() {
         // 입력 순서와 상관없이 최저 운임이 선택되어야 한다.
         List<EasyPostShipmentResponse.RateDto> rates = List.of(
@@ -88,27 +88,27 @@ class EasyPostInvoiceSaveServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] FedEx carrier는 FEDEX enum으로 매핑")
+    @DisplayName("FedEx 운송사 정보가 주어지면 송장을 생성하고 저장했을 때 FEDEX enum으로 매핑해야 한다")
     void fromEasyPostName_fedex() {
         assertThat(CarrierType.fromEasyPostName("FedEx")).isEqualTo(CarrierType.FEDEX);
         assertThat(CarrierType.fromEasyPostName("FEDEX")).isEqualTo(CarrierType.FEDEX);
     }
 
     @Test
-    @DisplayName("[GREEN] UPS carrier는 UPS enum으로 매핑")
+    @DisplayName("UPS 운송사 정보가 주어지면 송장을 생성하고 저장했을 때 UPS enum으로 매핑해야 한다")
     void fromEasyPostName_ups() {
         assertThat(CarrierType.fromEasyPostName("UPS")).isEqualTo(CarrierType.UPS);
     }
 
     @Test
-    @DisplayName("[GREEN] 알 수 없는 carrier는 USPS enum으로 매핑")
+    @DisplayName("알 수 없는 운송사 정보가 주어지면 송장을 생성하고 저장했을 때 USPS enum으로 매핑해야 한다")
     void fromEasyPostName_unknown() {
         assertThat(CarrierType.fromEasyPostName("DHL")).isEqualTo(CarrierType.USPS);
         assertThat(CarrierType.fromEasyPostName(null)).isEqualTo(CarrierType.USPS);
     }
 
     @Test
-    @DisplayName("[GREEN] 필드 매핑 - invoiceNo, carrierType, freightChargeAmt, labelUrl 검증")
+    @DisplayName("송장 응답 정보가 주어지면 송장을 생성하고 저장했을 때 주요 필드를 정확히 매핑해야 한다")
     void createAndSaveInvoice_mapsFieldsCorrectly() {
         // 외부 응답이 엔티티 필드로 어떻게 변환되는지 캡처해서 본다.
         EasyPostShipmentResponse created = buildShipmentWithRates("shp_field_test",
@@ -138,7 +138,7 @@ class EasyPostInvoiceSaveServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[예외] rates가 null이면 BusinessException(INT-104)")
+    @DisplayName("운임 정보가 null이면 최저 운임을 선택했을 때 BusinessException(INT-104)를 발생시켜야 한다")
     void selectCheapestRate_throwsWhenNull() {
         assertThatThrownBy(() -> service.selectCheapestRate(null))
                 .isInstanceOf(BusinessException.class)
@@ -146,7 +146,7 @@ class EasyPostInvoiceSaveServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] rates가 빈 리스트이면 BusinessException(INT-104)")
+    @DisplayName("운임 정보가 빈 목록이면 최저 운임을 선택했을 때 BusinessException(INT-104)를 발생시켜야 한다")
     void selectCheapestRate_throwsWhenEmpty() {
         assertThatThrownBy(() -> service.selectCheapestRate(List.of()))
                 .isInstanceOf(BusinessException.class)
@@ -158,7 +158,7 @@ class EasyPostInvoiceSaveServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[예외] createShipment 401 → 예외 전파, save 미호출")
+    @DisplayName("createShipment 호출에서 401 오류가 발생하면 송장을 생성하고 저장했을 때 예외를 전파하고 저장하지 않아야 한다")
     void createAndSaveInvoice_propagates_whenUnauthorized() {
         given(easyPostApiClient.createShipment(any()))
                 .willThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
@@ -171,7 +171,7 @@ class EasyPostInvoiceSaveServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] buyRate 500 → 예외 전파, save 미호출")
+    @DisplayName("buyRate 호출에서 500 오류가 발생하면 송장을 생성하고 저장했을 때 예외를 전파하고 저장하지 않아야 한다")
     void createAndSaveInvoice_propagates_whenBuyRateServerError() {
         EasyPostShipmentResponse created = buildShipmentWithRates("shp_001",
                 List.of(buildRate("r1", "USPS", "6.40")));
@@ -185,7 +185,7 @@ class EasyPostInvoiceSaveServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] createShipment 응답에 rates가 없으면 BusinessException(INT-104)")
+    @DisplayName("createShipment 응답에 운임 정보가 없으면 송장을 생성하고 저장했을 때 BusinessException(INT-104)를 발생시켜야 한다")
     void createAndSaveInvoice_throwsWhenNoRates() {
         // 구매 가능한 rate가 없으면 저장 전에 즉시 실패해야 한다.
         EasyPostShipmentResponse created = buildShipmentWithRates("shp_001", List.of());
@@ -196,12 +196,80 @@ class EasyPostInvoiceSaveServiceTest {
         verify(invoiceRepository, never()).save(any());
     }
 
+    @Test
+    @DisplayName("selectedRate가 null이면 송장을 생성하고 저장했을 때 carrierType은 USPS로 freightChargeAmt는 0으로 저장해야 한다")
+    void createAndSaveInvoice_usesUspsWhenSelectedRateIsNull() {
+        EasyPostShipmentResponse created = buildShipmentWithRates("shp_null_rate",
+                List.of(buildRate("r1", "USPS", "5.50")));
+        EasyPostShipmentResponse bought = new EasyPostShipmentResponse();
+        bought.setId("shp_null_rate");
+
+        given(easyPostApiClient.createShipment(any())).willReturn(created);
+        given(easyPostApiClient.buyRate("shp_null_rate", "r1")).willReturn(bought);
+        given(invoiceRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        EasypostShipmentInvoice result = service.createAndSaveInvoice(buildRequest());
+
+        assertThat(result.getCarrierType()).isEqualTo(CarrierType.USPS);
+        assertThat(result.getFreightChargeAmt()).isZero();
+    }
+
+    @Test
+    @DisplayName("tracker와 trackingCode가 모두 없으면 송장을 생성하고 저장했을 때 trackingUrl을 null로 저장해야 한다")
+    void createAndSaveInvoice_returnsNullTrackingUrlWhenTrackerAndTrackingCodeMissing() {
+        EasyPostShipmentResponse created = buildShipmentWithRates("shp_no_track",
+                List.of(buildRate("r1", "USPS", "5.50")));
+        EasyPostShipmentResponse bought = buildBoughtShipment("shp_no_track", "USPS", "5.50",
+                "https://label.url/no-track.pdf", null);
+        bought.setTracker(null);
+        bought.setTrackingCode(null);
+
+        given(easyPostApiClient.createShipment(any())).willReturn(created);
+        given(easyPostApiClient.buyRate("shp_no_track", "r1")).willReturn(bought);
+        given(invoiceRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        EasypostShipmentInvoice result = service.createAndSaveInvoice(buildRequest());
+
+        assertThat(result.getTrackingUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("목적지 주소가 없으면 송장을 생성하고 저장했을 때 shipToAddress를 null로 저장해야 한다")
+    void createAndSaveInvoice_returnsNullShipToAddressWhenToAddressMissing() {
+        EasyPostShipmentResponse created = buildShipmentWithRates("shp_no_addr",
+                List.of(buildRate("r1", "USPS", "5.50")));
+        EasyPostShipmentResponse bought = buildBoughtShipment("shp_no_addr", "USPS", "5.50",
+                "https://label.url/no-addr.pdf", "https://track.easypost.com/no-addr");
+        bought.setToAddress(null);
+
+        given(easyPostApiClient.createShipment(any())).willReturn(created);
+        given(easyPostApiClient.buyRate("shp_no_addr", "r1")).willReturn(bought);
+        given(invoiceRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        EasypostShipmentInvoice result = service.createAndSaveInvoice(buildRequest());
+
+        assertThat(result.getShipToAddress()).isNull();
+    }
+
+    @Test
+    @DisplayName("운임 금액이 모두 숫자가 아니면 최저 운임을 선택했을 때 BusinessException(INT-104)를 발생시켜야 한다")
+    void selectCheapestRate_throwsWhenAllRatesAreNonNumeric() {
+        List<EasyPostShipmentResponse.RateDto> rates = List.of(
+                buildRate("r1", "USPS", "abc"),
+                buildRate("r2", "UPS", "free")
+        );
+
+        assertThatThrownBy(() -> service.selectCheapestRate(rates))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("운임 정보가 없습니다");
+    }
+
     // ─────────────────────────────────────────────────────────
     // createAndSaveBulkInvoices()
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] 대상 2건 — EasyPost 2회 호출, bulkAssignInvoice 1회 호출, successCount=2")
+    @DisplayName("미발급 주문 2건이 주어지면 일괄 송장을 생성했을 때 EasyPost를 두 번 호출하고 송장을 일괄 반영해야 한다")
     void createAndSaveBulkInvoices_fullHappyPath() {
         List<InvoiceTargetDto> targets = List.of(
                 buildTarget("ORD-BULK-001"), buildTarget("ORD-BULK-002"));
@@ -240,7 +308,7 @@ class EasyPostInvoiceSaveServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 대상 없으면 API 미호출, BulkInvoiceResponse(0, 0) 반환")
+    @DisplayName("미발급 주문이 없으면 일괄 송장을 생성했을 때 API를 호출하지 않고 처리 건수를 0으로 반환해야 한다")
     void createAndSaveBulkInvoices_emptyTargets_returnsZero() {
         given(channelOrderInvoiceMapper.findOrdersWithoutInvoice("seller-001")).willReturn(List.of());
 
@@ -254,7 +322,7 @@ class EasyPostInvoiceSaveServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 1건 EasyPost 실패 시 failCount=1, 나머지 successCount=1")
+    @DisplayName("일부 주문의 EasyPost 발급이 실패하면 일괄 송장을 생성했을 때 성공 건수와 실패 건수를 나누어 반환해야 한다")
     void createAndSaveBulkInvoices_oneFailure_countedAsFail() {
         List<InvoiceTargetDto> targets = List.of(
                 buildTarget("ORD-OK-001"), buildTarget("ORD-FAIL-001"));
@@ -281,7 +349,7 @@ class EasyPostInvoiceSaveServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] mapper 조회 중 예외 발생 시 전파된다")
+    @DisplayName("미발급 주문 조회 중 예외가 발생하면 일괄 송장을 생성했을 때 호출자에게 예외를 전파해야 한다")
     void createAndSaveBulkInvoices_propagatesMapperException() {
         given(channelOrderInvoiceMapper.findOrdersWithoutInvoice("seller-001"))
                 .willThrow(new RuntimeException("DB 연결 오류"));
@@ -292,6 +360,23 @@ class EasyPostInvoiceSaveServiceTest {
                 .hasMessageContaining("DB 연결 오류");
 
         verify(easyPostApiClient, never()).createShipment(any());
+    }
+
+    @Test
+    @DisplayName("모든 주문의 송장 발급이 실패하면 일괄 송장을 생성했을 때 송장 일괄 반영을 호출하지 않아야 한다")
+    void createAndSaveBulkInvoices_skipsBulkAssignWhenAllTargetsFail() {
+        List<InvoiceTargetDto> targets = List.of(
+                buildTarget("ORD-FAIL-001"), buildTarget("ORD-FAIL-002"));
+        given(channelOrderInvoiceMapper.findOrdersWithoutInvoice("seller-001")).willReturn(targets);
+        given(easyPostApiClient.createShipment(any()))
+                .willThrow(new RuntimeException("EasyPost 연결 오류"));
+
+        BulkInvoiceResponse response = service.createAndSaveBulkInvoices(
+                "seller-001", buildFromAddress(), buildParcel());
+
+        assertThat(response.getSuccessCount()).isZero();
+        assertThat(response.getFailCount()).isEqualTo(2);
+        verify(channelOrderCommandMapper, never()).bulkAssignInvoice(any());
     }
 
     // ─────────────────────────────────────────────────────────

--- a/src/test/java/com/conk/integration/command/application/service/InvoicePersistenceServiceTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/InvoicePersistenceServiceTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("InvoicePersistenceService 단위 테스트")
+@DisplayName("InvoicePersistenceService 테스트")
 class InvoicePersistenceServiceTest {
 
     @Mock private EasypostShipmentInvoiceRepository invoiceRepository;
@@ -32,7 +32,7 @@ class InvoicePersistenceServiceTest {
     private InvoicePersistenceService service;
 
     @Test
-    @DisplayName("[GREEN] invoice 저장 + order에 invoiceNo 할당 정상 흐름")
+    @DisplayName("송장과 주문이 주어지면 송장을 저장했을 때 주문에 송장 번호를 할당하고 함께 저장해야 한다")
     void saveInvoiceAndAssign_happyPath() {
         EasypostShipmentInvoice invoice = buildInvoice("shp_001");
         ChannelOrder order = buildOrder("ORD-001");
@@ -49,7 +49,7 @@ class InvoicePersistenceServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] invoiceRepository.save() 실패 → 예외 전파, channelOrderRepository.save() 미호출")
+    @DisplayName("송장 저장에 실패하면 송장을 저장했을 때 예외를 전파하고 주문 저장을 호출하지 않아야 한다")
     void saveInvoiceAndAssign_invoiceRepoFails_propagatesAndSkipsOrderSave() {
         EasypostShipmentInvoice invoice = buildInvoice("shp_dup");
         ChannelOrder order = buildOrder("ORD-002");
@@ -65,7 +65,7 @@ class InvoicePersistenceServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] invoice 저장 후 channelOrderRepository.save() 실패 → 예외 전파")
+    @DisplayName("송장 저장 후 주문 저장에 실패하면 송장을 저장했을 때 예외를 전파해야 한다")
     void saveInvoiceAndAssign_orderRepoFails_propagates() {
         EasypostShipmentInvoice invoice = buildInvoice("shp_002");
         ChannelOrder order = buildOrder("ORD-003");

--- a/src/test/java/com/conk/integration/command/application/service/ManualOrderInvoiceServiceTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/ManualOrderInvoiceServiceTest.java
@@ -3,6 +3,7 @@ package com.conk.integration.command.application.service;
 import com.conk.integration.command.application.dto.request.EasyPostCreateShipmentRequest;
 import com.conk.integration.command.application.dto.request.ManualOrderInvoiceRequest;
 import com.conk.integration.common.exception.BusinessException;
+import com.conk.integration.common.exception.ErrorCode;
 import com.conk.integration.command.application.dto.response.EasyPostShipmentResponse;
 import com.conk.integration.command.application.dto.response.ManualOrderInvoiceResponse;
 import com.conk.integration.command.domain.aggregate.ChannelOrder;
@@ -34,7 +35,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("ManualOrderInvoiceService 단위 테스트")
+@DisplayName("ManualOrderInvoiceService 테스트")
 class ManualOrderInvoiceServiceTest {
 
     @Mock private ChannelOrderRepository channelOrderRepository;
@@ -49,11 +50,11 @@ class ManualOrderInvoiceServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Nested
-    @DisplayName("정상 흐름")
+    @DisplayName("수동 주문 송장 발급 성공 테스트")
     class HappyPath {
 
         @Test
-        @DisplayName("[GREEN] 신규 주문 — 저장 → createShipment → shipmentId 기록 → buyRate → invoice 저장 → 응답 반환")
+        @DisplayName("신규 주문 요청이 주어지면 수동 주문 송장 발급을 수행했을 때 주문 저장부터 송장 응답 반환까지 순서대로 처리해야 한다")
         void issue_newOrder_fullFlow() {
             given(channelOrderRepository.findById("ORD-001")).willReturn(Optional.empty());
 
@@ -84,7 +85,7 @@ class ManualOrderInvoiceServiceTest {
         }
 
         @Test
-        @DisplayName("[GREEN] shipmentId가 ChannelOrder에 기록된다")
+        @DisplayName("신규 주문 요청이 주어지면 수동 주문 송장 발급을 수행했을 때 shipmentId를 주문에 기록해야 한다")
         void issue_shipmentIdIsRecordedBeforeBuyRate() {
             given(channelOrderRepository.findById("ORD-002")).willReturn(Optional.empty());
 
@@ -108,7 +109,7 @@ class ManualOrderInvoiceServiceTest {
         }
 
         @Test
-        @DisplayName("[GREEN] invoiceNo=null 재시도 — saveNewOrder 미호출, EasyPost 흐름만 진행")
+        @DisplayName("송장 번호가 없는 기존 주문이 주어지면 수동 주문 송장 발급을 수행했을 때 신규 주문 저장 없이 EasyPost 발급만 진행해야 한다")
         void issue_retryWithNullInvoice_skipsOrderSave() {
             ChannelOrder existingOrder = buildOrder("ORD-RETRY", null);
             given(channelOrderRepository.findById("ORD-RETRY")).willReturn(Optional.of(existingOrder));
@@ -131,7 +132,7 @@ class ManualOrderInvoiceServiceTest {
         }
 
         @Test
-        @DisplayName("[GREEN] 최저가 rate가 EasyPost buyRate에 전달된다")
+        @DisplayName("여러 운임 정보가 주어지면 수동 주문 송장 발급을 수행했을 때 최저 운임을 buyRate에 전달해야 한다")
         void issue_cheapestRateIsSelected() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-003", null));
@@ -151,6 +152,41 @@ class ManualOrderInvoiceServiceTest {
 
             verify(easyPostApiClient).buyRate("shp_003", "r_cheap");
         }
+
+        @Test
+        @DisplayName("주문 상품 목록이 null이어도 수동 주문 송장 발급을 수행했을 때 신규 주문을 정상 저장해야 한다")
+        void issue_savesOrderWhenItemsIsNull() {
+            given(channelOrderRepository.findById("ORD-NULL-ITEMS")).willReturn(Optional.empty());
+            given(channelOrderRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            EasyPostShipmentResponse created = buildShipmentWithRates("shp_null_items",
+                    List.of(buildRate("r1", "USPS", "5.50")));
+            EasyPostShipmentResponse bought = buildBoughtShipment("shp_null_items", "USPS", "5.50");
+            given(easyPostApiClient.createShipment(any())).willReturn(created);
+            given(easyPostApiClient.buyRate("shp_null_items", "r1")).willReturn(bought);
+            given(invoicePersistenceService.saveInvoiceAndAssign(any(), any()))
+                    .willReturn(buildInvoice("shp_null_items", "USPS", 550));
+
+            ManualOrderInvoiceRequest request = new ManualOrderInvoiceRequest(
+                    "ORD-NULL-ITEMS",
+                    "홍길동", "010-1234-5678",
+                    "123 Main St", null,
+                    "CA", "Los Angeles", "90001",
+                    null,
+                    EasyPostCreateShipmentRequest.AddressBody.builder()
+                            .name("CONK Warehouse").street1("456 Warehouse Blvd")
+                            .city("Los Angeles").state("CA").zip("90002").country("US").build(),
+                    EasyPostCreateShipmentRequest.ParcelBody.builder()
+                            .weight(10.0).length(10.0).width(8.0).height(4.0).build()
+            );
+
+            ManualOrderInvoiceResponse response = service.issue("seller-001", request);
+
+            assertThat(response.getOrderId()).isEqualTo("ORD-NULL-ITEMS");
+            ArgumentCaptor<ChannelOrder> captor = ArgumentCaptor.forClass(ChannelOrder.class);
+            verify(channelOrderRepository, atLeastOnce()).save(captor.capture());
+            assertThat(captor.getAllValues().get(0).getItems()).isEmpty();
+        }
     }
 
     // ─────────────────────────────────────────────────────────
@@ -158,11 +194,11 @@ class ManualOrderInvoiceServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Nested
-    @DisplayName("예외 케이스")
+    @DisplayName("수동 주문 송장 발급 예외 테스트")
     class ExceptionCases {
 
         @Test
-        @DisplayName("[예외] 이미 invoiceNo가 있는 주문 재요청 → BusinessException(INT-201)")
+        @DisplayName("이미 송장 번호가 있는 주문이 주어지면 수동 주문 송장 발급을 수행했을 때 BusinessException(INT-201)을 발생시켜야 한다")
         void issue_alreadyInvoiced_throwsIllegalState() {
             ChannelOrder alreadyInvoiced = buildOrder("ORD-DONE", "shp_existing");
             given(channelOrderRepository.findById("ORD-DONE")).willReturn(Optional.of(alreadyInvoiced));
@@ -175,7 +211,7 @@ class ManualOrderInvoiceServiceTest {
         }
 
         @Test
-        @DisplayName("[예외] createShipment 실패 → 예외 전파, buyRate/invoice 미호출")
+        @DisplayName("createShipment 호출에 실패하면 수동 주문 송장 발급을 수행했을 때 예외를 전파하고 buyRate와 송장 저장을 호출하지 않아야 한다")
         void issue_createShipmentFails_propagates() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-004", null));
@@ -191,7 +227,7 @@ class ManualOrderInvoiceServiceTest {
         }
 
         @Test
-        @DisplayName("[예외] buyRate 실패 → 예외 전파, invoice 미저장")
+        @DisplayName("buyRate 호출에 실패하면 수동 주문 송장 발급을 수행했을 때 예외를 전파하고 송장을 저장하지 않아야 한다")
         void issue_buyRateFails_propagates() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-005", null));
@@ -210,7 +246,7 @@ class ManualOrderInvoiceServiceTest {
         }
 
         @Test
-        @DisplayName("[예외] rates가 없으면 BusinessException(INT-104)")
+        @DisplayName("운임 정보가 없으면 수동 주문 송장 발급을 수행했을 때 BusinessException(INT-104)를 발생시켜야 한다")
         void issue_noRates_throwsIllegalState() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-006", null));
@@ -224,7 +260,7 @@ class ManualOrderInvoiceServiceTest {
         }
 
         @Test
-        @DisplayName("[예외] toAddress가 올바르게 구성되어 EasyPost에 전달된다")
+        @DisplayName("배송지 정보가 주어지면 수동 주문 송장 발급을 수행했을 때 toAddress를 올바르게 구성해 EasyPost에 전달해야 한다")
         void issue_toAddressBuiltFromRequest() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-007", null));
@@ -253,7 +289,7 @@ class ManualOrderInvoiceServiceTest {
         // ── P1: EasyPost 외부 API 에러 ──────────────────────────
 
         @Test
-        @DisplayName("[예외] createShipment 401 → HttpClientErrorException 전파, buyRate/invoice 미호출")
+        @DisplayName("createShipment 호출에서 401 오류가 발생하면 수동 주문 송장 발급을 수행했을 때 HttpClientErrorException을 전파해야 한다")
         void issue_easyPost401_propagates() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-E01", null));
@@ -270,7 +306,7 @@ class ManualOrderInvoiceServiceTest {
         }
 
         @Test
-        @DisplayName("[예외] createShipment 422 (잘못된 주소) → HttpClientErrorException 전파")
+        @DisplayName("createShipment 호출에서 422 오류가 발생하면 수동 주문 송장 발급을 수행했을 때 HttpClientErrorException을 전파해야 한다")
         void issue_easyPost422_propagates() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-E02", null));
@@ -286,7 +322,7 @@ class ManualOrderInvoiceServiceTest {
         }
 
         @Test
-        @DisplayName("[예외] buyRate 500 → HttpServerErrorException 전파, invoice 미저장")
+        @DisplayName("buyRate 호출에서 500 오류가 발생하면 수동 주문 송장 발급을 수행했을 때 HttpServerErrorException을 전파하고 송장을 저장하지 않아야 한다")
         void issue_easyPost500OnBuyRate_propagates() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-E03", null));
@@ -308,7 +344,7 @@ class ManualOrderInvoiceServiceTest {
         // ── P2: DB 저장 실패 ──────────────────────────────────
 
         @Test
-        @DisplayName("[예외] shipmentId 기록 save() 실패 → 예외 전파, buyRate/invoice 미호출")
+        @DisplayName("shipmentId 기록 저장에 실패하면 수동 주문 송장 발급을 수행했을 때 예외를 전파하고 buyRate와 송장 저장을 호출하지 않아야 한다")
         void issue_shipmentIdRecordFails_propagates() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             // 첫 번째 save(신규 주문)는 성공, 두 번째 save(shipmentId 기록)는 실패
@@ -329,7 +365,7 @@ class ManualOrderInvoiceServiceTest {
         }
 
         @Test
-        @DisplayName("[예외] saveInvoiceAndAssign() 실패 → 예외 전파 (buyRate는 이미 호출됨)")
+        @DisplayName("송장 저장과 할당에 실패하면 수동 주문 송장 발급을 수행했을 때 예외를 전파해야 한다")
         void issue_invoicePersistenceFails_propagates() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-E05", null));
@@ -353,7 +389,7 @@ class ManualOrderInvoiceServiceTest {
         // ── P3: null 필드 안전 처리 ───────────────────────────
 
         @Test
-        @DisplayName("[GREEN] tracker=null → NPE 없이 trackingUrl이 trackingCode 기반으로 설정됨")
+        @DisplayName("tracker가 null이면 수동 주문 송장 발급을 수행했을 때 trackingCode 기반으로 trackingUrl을 설정해야 한다")
         void issue_trackerNull_handledGracefully() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-N01", null));
@@ -377,7 +413,7 @@ class ManualOrderInvoiceServiceTest {
         }
 
         @Test
-        @DisplayName("[GREEN] postageLabel=null → NPE 없이 labelFileUrl=null로 처리됨")
+        @DisplayName("postageLabel이 null이면 수동 주문 송장 발급을 수행했을 때 labelFileUrl을 null로 처리해야 한다")
         void issue_postageLabelNull_handledGracefully() {
             given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
             given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-N02", null));
@@ -398,6 +434,97 @@ class ManualOrderInvoiceServiceTest {
             service.issue("seller-001", buildRequest("ORD-N02"));
 
             assertThat(captor.getValue().getLabelFileUrl()).isNull();
+        }
+
+        @Test
+        @DisplayName("tracker와 trackingCode가 모두 null이면 수동 주문 송장 발급을 수행했을 때 trackingUrl을 null로 저장해야 한다")
+        void issue_returnsNullTrackingUrlWhenTrackerAndTrackingCodeMissing() {
+            given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
+            given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-N03", null));
+
+            EasyPostShipmentResponse created = buildShipmentWithRates("shp_n03",
+                    List.of(buildRate("r1", "USPS", "5.00")));
+            given(easyPostApiClient.createShipment(any())).willReturn(created);
+
+            EasyPostShipmentResponse bought = buildBoughtShipment("shp_n03", "USPS", "5.00");
+            bought.setTracker(null);
+            bought.setTrackingCode(null);
+            given(easyPostApiClient.buyRate(anyString(), anyString())).willReturn(bought);
+
+            ArgumentCaptor<EasypostShipmentInvoice> captor =
+                    ArgumentCaptor.forClass(EasypostShipmentInvoice.class);
+            given(invoicePersistenceService.saveInvoiceAndAssign(captor.capture(), any()))
+                    .willAnswer(inv -> inv.getArgument(0));
+
+            service.issue("seller-001", buildRequest("ORD-N03"));
+
+            assertThat(captor.getValue().getTrackingUrl()).isNull();
+        }
+
+        @Test
+        @DisplayName("목적지 주소가 null이면 수동 주문 송장 발급을 수행했을 때 shipToAddress를 null로 저장해야 한다")
+        void issue_returnsNullShipToAddressWhenResponseAddressMissing() {
+            given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
+            given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-N04", null));
+
+            EasyPostShipmentResponse created = buildShipmentWithRates("shp_n04",
+                    List.of(buildRate("r1", "USPS", "5.00")));
+            given(easyPostApiClient.createShipment(any())).willReturn(created);
+
+            EasyPostShipmentResponse bought = buildBoughtShipment("shp_n04", "USPS", "5.00");
+            bought.setToAddress(null);
+            given(easyPostApiClient.buyRate(anyString(), anyString())).willReturn(bought);
+
+            ArgumentCaptor<EasypostShipmentInvoice> captor =
+                    ArgumentCaptor.forClass(EasypostShipmentInvoice.class);
+            given(invoicePersistenceService.saveInvoiceAndAssign(captor.capture(), any()))
+                    .willAnswer(inv -> inv.getArgument(0));
+
+            service.issue("seller-001", buildRequest("ORD-N04"));
+
+            assertThat(captor.getValue().getShipToAddress()).isNull();
+        }
+
+        @Test
+        @DisplayName("selectedRate가 null이면 수동 주문 송장 발급을 수행했을 때 carrierType은 USPS로 freightChargeAmt는 0으로 저장해야 한다")
+        void issue_usesUspsWhenSelectedRateIsNull() {
+            given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
+            given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-N05", null));
+
+            EasyPostShipmentResponse created = buildShipmentWithRates("shp_n05",
+                    List.of(buildRate("r1", "USPS", "5.00")));
+            given(easyPostApiClient.createShipment(any())).willReturn(created);
+
+            EasyPostShipmentResponse bought = new EasyPostShipmentResponse();
+            bought.setId("shp_n05");
+            given(easyPostApiClient.buyRate(anyString(), anyString())).willReturn(bought);
+
+            ArgumentCaptor<EasypostShipmentInvoice> captor =
+                    ArgumentCaptor.forClass(EasypostShipmentInvoice.class);
+            given(invoicePersistenceService.saveInvoiceAndAssign(captor.capture(), any()))
+                    .willAnswer(inv -> inv.getArgument(0));
+
+            service.issue("seller-001", buildRequest("ORD-N05"));
+
+            assertThat(captor.getValue().getCarrierType()).isEqualTo(CarrierType.USPS);
+            assertThat(captor.getValue().getFreightChargeAmt()).isZero();
+        }
+
+        @Test
+        @DisplayName("운임 금액이 모두 숫자가 아니면 수동 주문 송장 발급을 수행했을 때 BusinessException(INT-104)를 발생시켜야 한다")
+        void issue_selectCheapestRate_throwsWhenAllRatesAreNonNumeric() {
+            given(channelOrderRepository.findById(any())).willReturn(Optional.empty());
+            given(channelOrderRepository.save(any())).willReturn(buildOrder("ORD-N06", null));
+            given(easyPostApiClient.createShipment(any())).willReturn(buildShipmentWithRates("shp_n06",
+                    List.of(buildRate("r1", "USPS", "abc"), buildRate("r2", "UPS", "free"))));
+
+            assertThatThrownBy(() -> service.issue("seller-001", buildRequest("ORD-N06")))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.NO_SHIPPING_RATES);
+
+            verify(easyPostApiClient, never()).buyRate(anyString(), anyString());
+            verify(invoicePersistenceService, never()).saveInvoiceAndAssign(any(), any());
         }
     }
 

--- a/src/test/java/com/conk/integration/command/application/service/SellerChannelConnectServiceTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/SellerChannelConnectServiceTest.java
@@ -1,0 +1,163 @@
+package com.conk.integration.command.application.service;
+
+import com.conk.integration.command.application.dto.request.SellerChannelConnectRequest;
+import com.conk.integration.command.domain.aggregate.ChannelApi;
+import com.conk.integration.command.domain.aggregate.embeddable.AuditFields;
+import com.conk.integration.command.domain.aggregate.embeddable.ChannelApiId;
+import com.conk.integration.command.infrastructure.repository.ChannelApiRepository;
+import com.conk.integration.common.exception.BusinessException;
+import com.conk.integration.common.exception.ErrorCode;
+import com.conk.integration.query.dto.SellerChannelDetailDto;
+import com.conk.integration.query.service.ShopifyPingClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SellerChannelConnectService 테스트")
+class SellerChannelConnectServiceTest {
+
+    @Mock
+    private ChannelApiRepository channelApiRepository;
+
+    @Mock
+    private ShopifyPingClient shopifyPingClient;
+
+    @InjectMocks
+    private SellerChannelConnectService service;
+
+    @Test
+    @DisplayName("유효한 sellerId와 Shopify 연결 정보가 주어지면 채널 연결을 수행했을 때 신규 ChannelApi를 저장해야 한다")
+    void connect_validRequest_savesNewChannelApi() {
+        SellerChannelConnectRequest request = new SellerChannelConnectRequest(
+                "my-shopify-store", "shpat_token", "Shopify KR Store", "ops@example.com", "AUTO");
+        given(shopifyPingClient.ping("my-shopify-store", "shpat_token")).willReturn(true);
+        given(channelApiRepository.findById(new ChannelApiId("seller-001", "SHOPIFY"))).willReturn(Optional.empty());
+        given(channelApiRepository.saveAndFlush(any(ChannelApi.class))).willAnswer(invocation -> {
+            ChannelApi entity = invocation.getArgument(0);
+            if (entity.getAudit().getCreatedAt() == null) {
+                entity.getAudit().setCreatedAt(LocalDateTime.of(2026, 4, 10, 11, 0));
+            }
+            return entity;
+        });
+
+        SellerChannelDetailDto result = service.connect("seller-001", "shopify", request);
+
+        assertThat(result.getChannelName()).isEqualTo("SHOPIFY");
+        assertThat(result.getStoreName()).isEqualTo("my-shopify-store");
+        assertThat(result.getChannelApi()).isEqualTo("shpat_token");
+        verify(channelApiRepository).saveAndFlush(any(ChannelApi.class));
+    }
+
+    @Test
+    @DisplayName("동일 sellerId와 channelKey의 연결 정보가 이미 있으면 채널 연결을 수행했을 때 기존 ChannelApi를 갱신해야 한다")
+    void connect_existingConnection_updatesChannelApi() {
+        ChannelApi existing = ChannelApi.builder()
+                .id(new ChannelApiId("seller-001", "SHOPIFY"))
+                .channelApi("old-token")
+                .storeName("old-store")
+                .audit(AuditFields.builder().createdAt(LocalDateTime.of(2026, 4, 1, 9, 0)).build())
+                .build();
+        SellerChannelConnectRequest request = new SellerChannelConnectRequest(
+                "new-store", "new-token", "Shopify KR Store", "ops@example.com", "AUTO");
+
+        given(shopifyPingClient.ping("new-store", "new-token")).willReturn(true);
+        given(channelApiRepository.findById(new ChannelApiId("seller-001", "SHOPIFY"))).willReturn(Optional.of(existing));
+        given(channelApiRepository.saveAndFlush(existing)).willReturn(existing);
+
+        SellerChannelDetailDto result = service.connect("seller-001", "SHOPIFY", request);
+
+        assertThat(existing.getStoreName()).isEqualTo("new-store");
+        assertThat(existing.getChannelApi()).isEqualTo("new-token");
+        assertThat(result.getConnectedAt()).isEqualTo(LocalDateTime.of(2026, 4, 1, 9, 0));
+    }
+
+    @Test
+    @DisplayName("sellerId가 공백이면 채널 연결을 수행했을 때 BusinessException(INT-001)을 발생시키고 repository를 호출하지 않아야 한다")
+    void connect_blankSellerId_throwsInvalidSellerId() {
+        assertThatThrownBy(() -> service.connect("   ", "SHOPIFY", validRequest()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_SELLER_ID);
+
+        verifyNoInteractions(channelApiRepository);
+    }
+
+    @Test
+    @DisplayName("channelKey가 공백이면 채널 연결을 수행했을 때 BusinessException(INT-004)을 발생시켜야 한다")
+    void connect_blankChannelKey_throwsUnsupportedChannel() {
+        assertThatThrownBy(() -> service.connect("seller-001", "   ", validRequest()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.UNSUPPORTED_CHANNEL);
+    }
+
+    @Test
+    @DisplayName("SHOPIFY가 아닌 채널 키가 주어지면 채널 연결을 수행했을 때 BusinessException(INT-004)을 발생시켜야 한다")
+    void connect_unsupportedChannel_throwsUnsupportedChannel() {
+        assertThatThrownBy(() -> service.connect("seller-001", "AMAZON", validRequest()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.UNSUPPORTED_CHANNEL);
+
+        verifyNoInteractions(channelApiRepository);
+    }
+
+    @Test
+    @DisplayName("storeName이 없으면 채널 연결을 수행했을 때 BusinessException(INT-001)을 발생시켜야 한다")
+    void connect_blankStoreName_throwsInvalidSellerId() {
+        SellerChannelConnectRequest request = new SellerChannelConnectRequest(
+                " ", "shpat_token", "Shopify KR Store", "ops@example.com", "AUTO");
+
+        assertThatThrownBy(() -> service.connect("seller-001", "SHOPIFY", request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("storeName는 필수입니다.");
+
+        verifyNoInteractions(channelApiRepository);
+    }
+
+    @Test
+    @DisplayName("channelApi가 없으면 채널 연결을 수행했을 때 BusinessException(INT-001)을 발생시켜야 한다")
+    void connect_blankChannelApi_throwsInvalidSellerId() {
+        SellerChannelConnectRequest request = new SellerChannelConnectRequest(
+                "my-shopify-store", " ", "Shopify KR Store", "ops@example.com", "AUTO");
+
+        assertThatThrownBy(() -> service.connect("seller-001", "SHOPIFY", request))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("channelApi는 필수입니다.");
+
+        verifyNoInteractions(channelApiRepository);
+    }
+
+    @Test
+    @DisplayName("Shopify 연결 검증에 실패하면 채널 연결을 수행했을 때 저장하지 않고 BusinessException(INT-404)를 발생시켜야 한다")
+    void connect_pingFails_throwsNotFound() {
+        SellerChannelConnectRequest request = validRequest();
+        given(shopifyPingClient.ping("my-shopify-store", "shpat_token")).willReturn(false);
+
+        assertThatThrownBy(() -> service.connect("seller-001", "SHOPIFY", request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHANNEL_CONNECTION_NOT_FOUND);
+
+        verifyNoInteractions(channelApiRepository);
+    }
+
+    private SellerChannelConnectRequest validRequest() {
+        return new SellerChannelConnectRequest(
+                "my-shopify-store", "shpat_token", "Shopify KR Store", "ops@example.com", "AUTO");
+    }
+}

--- a/src/test/java/com/conk/integration/command/application/service/ShopifyOrderSyncServiceTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/ShopifyOrderSyncServiceTest.java
@@ -34,7 +34,7 @@ import static org.mockito.BDDMockito.times;
 
 // Shopify 주문 동기화 서비스의 GraphQL 매핑, 중복 방지, 예외 전파를 검증한다.
 @ExtendWith(MockitoExtension.class)
-@DisplayName("ShopifyOrderSyncService Tests")
+@DisplayName("ShopifyOrderSyncService 테스트")
 class ShopifyOrderSyncServiceTest {
 
     @Mock private ShopifyOrderClient shopifyOrderClient;
@@ -58,7 +58,7 @@ class ShopifyOrderSyncServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("신규 주문을 channel_order 테이블에 저장한다")
+    @DisplayName("신규 주문이 주어지면 주문 동기화를 수행했을 때 channel_order 테이블에 저장해야 한다")
     void syncOrders_savesNewOrderToRepository() {
         ShopifyOrderResponse.OrderNode node = buildOrderNode(
                 "gid://shopify/Order/4502818226334", "#1001", "2024-01-15T10:00:00-05:00",
@@ -73,7 +73,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("이미 저장된 주문은 skip한다 (중복 저장 방지)")
+    @DisplayName("이미 저장된 주문이 주어지면 주문 동기화를 수행했을 때 중복 저장을 건너뛰어야 한다")
     void syncOrders_skipsDuplicateOrder() {
         ShopifyOrderResponse.OrderNode node = buildOrderNode(
                 "gid://shopify/Order/4502818226334", "#1001", "2024-01-15T10:00:00-05:00",
@@ -88,7 +88,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("여러 주문 중 신규 건만 저장한다")
+    @DisplayName("기존 주문과 신규 주문이 함께 주어지면 주문 동기화를 수행했을 때 신규 주문만 저장해야 한다")
     void syncOrders_savesOnlyNewOrders_whenMixedExistence() {
         ShopifyOrderResponse.OrderNode existing = buildOrderNode(
                 "gid://shopify/Order/1000", "#1000", "2024-01-10T00:00:00-05:00", null);
@@ -109,7 +109,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("API 주문 목록이 빈 경우 save를 호출하지 않는다")
+    @DisplayName("API 주문 목록이 비어 있으면 주문 동기화를 수행했을 때 save를 호출하지 않아야 한다")
     void syncOrders_doesNotSave_whenNoOrdersReturned() {
         given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
         given(shopifyOrderClient.getOrders(anyString(), anyString())).willReturn(List.of());
@@ -124,7 +124,7 @@ class ShopifyOrderSyncServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("GID에서 숫자 ID를 추출하고 주소/채널 필드를 정확히 매핑한다")
+    @DisplayName("Shopify 주문 정보가 주어지면 주문 동기화를 수행했을 때 GID 숫자 ID와 주소 및 채널 필드를 정확히 매핑해야 한다")
     void syncOrders_mapsFieldsCorrectly() {
         ShopifyOrderResponse.OrderNode node = buildOrderNode(
                 "gid://shopify/Order/4502818226334", "#1001", "2024-01-15T10:00:00-05:00",
@@ -161,7 +161,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("fulfillmentOrders 첫 번째 항목 GID가 fulfillmentOrderId로 저장된다")
+    @DisplayName("fulfillmentOrders가 포함된 주문이 주어지면 주문 동기화를 수행했을 때 첫 번째 GID를 fulfillmentOrderId로 저장해야 한다")
     void syncOrders_savesFulfillmentOrderId() {
         ShopifyOrderResponse.OrderNode node = buildOrderNode(
                 "gid://shopify/Order/5000", "#5000", "2024-01-20T10:00:00-05:00",
@@ -181,7 +181,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("fulfillmentOrders가 없으면 fulfillmentOrderId=null로 저장된다")
+    @DisplayName("fulfillmentOrders가 없으면 주문 동기화를 수행했을 때 fulfillmentOrderId를 null로 저장해야 한다")
     void syncOrders_savesFulfillmentOrderIdAsNull_whenFulfillmentOrdersEmpty() {
         ShopifyOrderResponse.OrderNode node = buildOrderNode(
                 "gid://shopify/Order/6000", "#6000", "2024-01-20T10:00:00-05:00", null);
@@ -199,7 +199,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("shippingAddress가 null인 주문도 NPE 없이 저장 성공")
+    @DisplayName("shippingAddress가 null인 주문이 주어지면 주문 동기화를 수행했을 때 예외 없이 저장해야 한다")
     void syncOrders_savesOrder_whenShippingAddressIsNull() {
         ShopifyOrderResponse.OrderNode node = new ShopifyOrderResponse.OrderNode();
         node.setId("gid://shopify/Order/9999");
@@ -222,7 +222,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("createdAt이 null이면 orderedAt=null로 저장 성공")
+    @DisplayName("createdAt이 null인 주문이 주어지면 주문 동기화를 수행했을 때 orderedAt을 null로 저장해야 한다")
     void syncOrders_savesOrder_whenCreatedAtIsNull() {
         ShopifyOrderResponse.OrderNode node = buildOrderNode(
                 "gid://shopify/Order/8888", "#8888", null, null);
@@ -243,7 +243,7 @@ class ShopifyOrderSyncServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("createdAt이 공백 문자열이면 orderedAt=null로 저장된다")
+    @DisplayName("createdAt이 공백 문자열인 주문이 주어지면 주문 동기화를 수행했을 때 orderedAt을 null로 저장해야 한다")
     void syncOrders_savesOrder_whenCreatedAtIsBlank() {
         ShopifyOrderResponse.OrderNode node = buildOrderNode(
                 "gid://shopify/Order/7777", "#7777", "   ", null);
@@ -260,7 +260,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("repository save 중 예외 발생 시 호출자에게 전파된다")
+    @DisplayName("주문 저장 중 예외가 발생하면 주문 동기화를 수행했을 때 호출자에게 예외를 전파해야 한다")
     void syncOrders_propagatesException_whenRepositorySaveThrows() {
         ShopifyOrderResponse.OrderNode node = buildOrderNode(
                 "gid://shopify/Order/1111", "#1111", "2024-01-15T10:00:00-05:00", null);
@@ -276,7 +276,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("API 호출 시 401이 발생하면 예외가 호출자에게 전파된다")
+    @DisplayName("API 호출에서 401 오류가 발생하면 주문 동기화를 수행했을 때 호출자에게 예외를 전파해야 한다")
     void syncOrders_propagatesException_whenApiClientThrowsUnauthorized() {
         given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
         given(shopifyOrderClient.getOrders(anyString(), anyString()))
@@ -290,7 +290,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("API 호출 시 500이 발생하면 예외가 호출자에게 전파된다")
+    @DisplayName("API 호출에서 500 오류가 발생하면 주문 동기화를 수행했을 때 호출자에게 예외를 전파해야 한다")
     void syncOrders_propagatesException_whenApiClientThrowsServerError() {
         given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
         given(shopifyOrderClient.getOrders(anyString(), anyString()))
@@ -306,7 +306,7 @@ class ShopifyOrderSyncServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("line item의 sku가 있으면 sku를 skuId로 사용해 ChannelOrderItem을 저장한다")
+    @DisplayName("line item에 sku가 있으면 주문 동기화를 수행했을 때 sku를 skuId로 사용해 주문 아이템을 저장해야 한다")
     void syncOrders_savesChannelOrderItem_whenSkuPresent() {
         ShopifyOrderResponse.OrderNode node = buildOrderNode(
                 "gid://shopify/Order/2000", "#2000", "2024-02-01T10:00:00-05:00", null);
@@ -330,7 +330,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("sku가 비어있고 variant id가 있으면 variant GID 끝 숫자를 skuId로 사용한다")
+    @DisplayName("sku가 비어 있고 variant id가 있으면 주문 동기화를 수행했을 때 variant GID 끝 숫자를 skuId로 사용해야 한다")
     void syncOrders_usesVariantIdAsSkuId_whenSkuIsBlank() {
         ShopifyOrderResponse.OrderNode node = buildOrderNode(
                 "gid://shopify/Order/3000", "#3000", "2024-02-01T10:00:00-05:00", null);
@@ -350,7 +350,7 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("lineItems가 null이어도 주문 자체는 정상 저장된다")
+    @DisplayName("lineItems가 null이어도 주문 동기화를 수행했을 때 주문 자체는 정상 저장해야 한다")
     void syncOrders_savesOrderWithoutItems_whenLineItemsIsNull() {
         ShopifyOrderResponse.OrderNode node = buildOrderNode(
                 "gid://shopify/Order/4000", "#4000", "2024-02-01T10:00:00-05:00", null);
@@ -368,7 +368,49 @@ class ShopifyOrderSyncServiceTest {
     }
 
     @Test
-    @DisplayName("syncOrders 반환값에 savedCount와 skippedCount가 정확히 포함된다")
+    @DisplayName("sku와 variant id가 모두 없으면 주문 동기화를 수행했을 때 해당 line item 저장을 건너뛰어야 한다")
+    void syncOrders_skipsLineItemWhenSkuAndVariantIdMissing() {
+        ShopifyOrderResponse.OrderNode node = buildOrderNode(
+                "gid://shopify/Order/4100", "#4100", "2024-02-01T10:00:00-05:00", null);
+        node.setLineItems(buildLineItemConnection(null, "Product Without SKU", 1, null));
+
+        given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
+        given(shopifyOrderClient.getOrders(anyString(), anyString())).willReturn(List.of(node));
+        given(channelOrderRepository.existsById("4100")).willReturn(false);
+
+        syncService.syncOrders(SELLER_ID);
+
+        ArgumentCaptor<ChannelOrder> captor = ArgumentCaptor.forClass(ChannelOrder.class);
+        then(channelOrderRepository).should().save(captor.capture());
+        assertThat(captor.getValue().getItems()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("fulfillment order node id가 null이면 주문 동기화를 수행했을 때 fulfillmentOrderId를 null로 저장해야 한다")
+    void syncOrders_returnsNullFulfillmentOrderIdWhenFulfillmentOrderNodeIdMissing() {
+        ShopifyOrderResponse.OrderNode node = buildOrderNode(
+                "gid://shopify/Order/6100", "#6100", "2024-02-01T10:00:00-05:00", null);
+        ShopifyOrderResponse.FulfillmentOrderNode fulfillmentOrderNode = new ShopifyOrderResponse.FulfillmentOrderNode();
+        fulfillmentOrderNode.setId(null);
+        ShopifyOrderResponse.FulfillmentOrderEdge fulfillmentOrderEdge = new ShopifyOrderResponse.FulfillmentOrderEdge();
+        fulfillmentOrderEdge.setNode(fulfillmentOrderNode);
+        ShopifyOrderResponse.FulfillmentOrderConnection connection = new ShopifyOrderResponse.FulfillmentOrderConnection();
+        connection.setEdges(List.of(fulfillmentOrderEdge));
+        node.setFulfillmentOrders(connection);
+
+        given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
+        given(shopifyOrderClient.getOrders(anyString(), anyString())).willReturn(List.of(node));
+        given(channelOrderRepository.existsById("6100")).willReturn(false);
+
+        syncService.syncOrders(SELLER_ID);
+
+        ArgumentCaptor<ChannelOrder> captor = ArgumentCaptor.forClass(ChannelOrder.class);
+        then(channelOrderRepository).should().save(captor.capture());
+        assertThat(captor.getValue().getFulfillmentOrderId()).isNull();
+    }
+
+    @Test
+    @DisplayName("기존 주문과 신규 주문이 함께 주어지면 주문 동기화를 수행했을 때 savedCount와 skippedCount를 정확히 반환해야 한다")
     void syncOrders_returnsSavedAndSkippedCount() {
         ShopifyOrderResponse.OrderNode existing = buildOrderNode(
                 "gid://shopify/Order/5000", "#5000", "2024-02-01T10:00:00-05:00", null);

--- a/src/test/java/com/conk/integration/command/application/service/shopify/ShopifyFulfillmentSenderTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/shopify/ShopifyFulfillmentSenderTest.java
@@ -32,7 +32,7 @@ import static org.mockito.BDDMockito.willThrow;
 
 // Shopify sender가 채널 지원 여부와 요청 변환을 올바르게 수행하는지 검증한다.
 @ExtendWith(MockitoExtension.class)
-@DisplayName("ShopifyFulfillmentSender 단위 테스트")
+@DisplayName("ShopifyFulfillmentSender 테스트")
 class ShopifyFulfillmentSenderTest {
 
     @Mock
@@ -53,7 +53,7 @@ class ShopifyFulfillmentSenderTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("supports() — SHOPIFY 채널만 true를 반환한다")
+    @DisplayName("Shopify 채널이 주어지면 지원 여부를 확인했을 때 true를 반환해야 한다")
     void supports_returnsTrueOnlyForShopify() {
         assertThat(sender.supports(OrderChannel.SHOPIFY)).isTrue();
         assertThat(sender.supports(OrderChannel.AMAZON)).isFalse();
@@ -65,7 +65,7 @@ class ShopifyFulfillmentSenderTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("send() — 주문/송장을 Shopify fulfillment 요청으로 변환해 API를 호출한다")
+    @DisplayName("주문과 송장 정보가 주어지면 fulfillment 전송을 수행했을 때 Shopify 요청으로 변환해 API를 호출해야 한다")
     void send_buildsRequestAndCallsApiClient() {
         given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
 
@@ -95,7 +95,7 @@ class ShopifyFulfillmentSenderTest {
     }
 
     @Test
-    @DisplayName("send() — Shopify API client 예외를 그대로 전파한다")
+    @DisplayName("Shopify API 호출 중 예외가 발생하면 fulfillment 전송을 수행했을 때 예외를 그대로 전파해야 한다")
     void send_propagatesExceptionFromClient() {
         given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
 
@@ -125,7 +125,7 @@ class ShopifyFulfillmentSenderTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("sendBulk() — FulfillmentTargetDto 목록을 그대로 apiClient.createBulkFulfillment()에 위임한다")
+    @DisplayName("일괄 fulfillment 대상이 주어지면 일괄 fulfillment 전송을 수행했을 때 API 호출에 그대로 위임해야 한다")
     void sendBulk_delegatesToApiClient() {
         given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
 
@@ -140,7 +140,7 @@ class ShopifyFulfillmentSenderTest {
     }
 
     @Test
-    @DisplayName("sendBulk() — apiClient 예외를 그대로 전파한다")
+    @DisplayName("일괄 fulfillment API 호출 중 예외가 발생하면 일괄 fulfillment 전송을 수행했을 때 예외를 그대로 전파해야 한다")
     void sendBulk_propagatesExceptionFromClient() {
         given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
 

--- a/src/test/java/com/conk/integration/command/domain/aggregate/ChannelApiTest.java
+++ b/src/test/java/com/conk/integration/command/domain/aggregate/ChannelApiTest.java
@@ -10,12 +10,12 @@ import java.time.LocalDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 // 순수 객체 생성 관점에서 ChannelApi의 값 보존만 검증한다.
-@DisplayName("ChannelApi Entity Tests")
+@DisplayName("ChannelApi 테스트")
 class ChannelApiTest {
 
     // 복합 키와 토큰이 빌더 입력 그대로 유지되는지 본다.
     @Test
-    @DisplayName("빌더로 생성하면 복합 키와 API 토큰이 그대로 설정된다")
+    @DisplayName("복합 키와 API 토큰이 주어지면 빌더로 생성했을 때 값이 그대로 설정되어야 한다")
     void builder_setsCompositeKeyAndApiToken() {
         ChannelApi api = ChannelApi.builder()
                 .id(new ChannelApiId("seller-001", "AMAZON"))
@@ -31,7 +31,7 @@ class ChannelApiTest {
 
     // 감사 필드는 영속화 없이도 단순 값 보존이 가능해야 한다.
     @Test
-    @DisplayName("생성 시 감사 필드를 지정하면 값이 유지된다")
+    @DisplayName("감사 필드가 주어지면 엔티티를 생성했을 때 값이 그대로 유지되어야 한다")
     void builder_keepsAuditFields() {
         LocalDateTime createdAt = LocalDateTime.of(2026, 3, 30, 9, 0);
         LocalDateTime updatedAt = createdAt.plusHours(1);

--- a/src/test/java/com/conk/integration/command/domain/aggregate/ChannelOrderEntityTest.java
+++ b/src/test/java/com/conk/integration/command/domain/aggregate/ChannelOrderEntityTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.*;
 
 /**
@@ -16,7 +18,7 @@ import static org.assertj.core.api.Assertions.*;
  * - 순수 Java 객체 수준에서 도메인 모델의 생성 / 상태 / 비즈니스 규칙을 검증합니다.
  * - Spring Context 없이 실행되므로 매우 빠릅니다.
  */
-@DisplayName("[Entity] 도메인 엔티티 단위 테스트")
+@DisplayName("도메인 엔티티 테스트")
 class ChannelOrderEntityTest {
 
     /* ===================================================================
@@ -24,12 +26,12 @@ class ChannelOrderEntityTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("ChannelOrder 엔티티")
+    @DisplayName("ChannelOrder 테스트")
     class ChannelOrderTests {
 
         // 주문 엔티티의 핵심 표시/식별 필드가 빌더 입력 그대로 유지되는지 본다.
         @Test
-        @DisplayName("Builder로 ChannelOrder를 생성하면 각 필드가 정상적으로 설정된다")
+        @DisplayName("주문 정보가 주어지면 ChannelOrder를 생성했을 때 각 필드가 올바르게 설정되어야 한다")
         void builder_setsAllFields() {
             // given & when
             ChannelOrder order = ChannelOrder.builder()
@@ -54,7 +56,7 @@ class ChannelOrderEntityTest {
         }
 
         @Test
-        @DisplayName("addItem()을 호출하면 items 리스트에 아이템이 추가된다")
+        @DisplayName("주문 아이템이 주어지면 addItem을 호출했을 때 items 목록에 추가되어야 한다")
         void addItem_addsToList() {
             // given
             ChannelOrder order = ChannelOrder.builder()
@@ -79,7 +81,7 @@ class ChannelOrderEntityTest {
         }
 
         @Test
-        @DisplayName("여러 아이템을 추가하면 모두 items 리스트에 누적된다")
+        @DisplayName("여러 주문 아이템이 주어지면 addItem을 호출했을 때 items 목록에 누적되어야 한다")
         void addItem_multipleItems_allAdded() {
             // 연속 addItem 호출이 누적 append로 동작해야 한다.
             // given
@@ -108,6 +110,73 @@ class ChannelOrderEntityTest {
             // then
             assertThat(order.getItems()).hasSize(2);
         }
+
+        @Test
+        @DisplayName("동기화 전 주문이 주어지면 markAsSynced를 호출했을 때 channelSyncYn이 true가 되어야 한다")
+        void markAsSynced_setsChannelSyncYnTrue() {
+            ChannelOrder order = ChannelOrder.builder()
+                    .orderId("order-sync")
+                    .sellerId("seller-A")
+                    .build();
+
+            order.markAsSynced();
+
+            assertThat(order.isChannelSyncYn()).isTrue();
+        }
+
+        @Test
+        @DisplayName("송장 번호가 주어지면 assignInvoice를 호출했을 때 invoiceNo가 설정되어야 한다")
+        void assignInvoice_setsInvoiceNo() {
+            ChannelOrder order = ChannelOrder.builder()
+                    .orderId("order-invoice")
+                    .sellerId("seller-A")
+                    .build();
+
+            order.assignInvoice("INV-001");
+
+            assertThat(order.getInvoiceNo()).isEqualTo("INV-001");
+        }
+
+        @Test
+        @DisplayName("shipmentId가 주어지면 assignShipmentId를 호출했을 때 shipmentId가 설정되어야 한다")
+        void assignShipmentId_setsShipmentId() {
+            ChannelOrder order = ChannelOrder.builder()
+                    .orderId("order-shipment")
+                    .sellerId("seller-A")
+                    .build();
+
+            order.assignShipmentId("shp_001");
+
+            assertThat(order.getShipmentId()).isEqualTo("shp_001");
+        }
+
+        @Test
+        @DisplayName("감사 필드가 없는 엔티티가 주어지면 onCreate를 호출했을 때 createdAt과 updatedAt을 채워야 한다")
+        void onCreate_setsAuditCreatedAtAndUpdatedAt() {
+            ChannelOrder order = ChannelOrder.builder()
+                    .orderId("order-audit")
+                    .sellerId("seller-A")
+                    .build();
+
+            order.onCreate();
+
+            assertThat(order.getAudit().getCreatedAt()).isNotNull();
+            assertThat(order.getAudit().getUpdatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("감사 필드가 있는 엔티티가 주어지면 onUpdate를 호출했을 때 updatedAt을 갱신해야 한다")
+        void onUpdate_updatesAuditUpdatedAt() {
+            ChannelOrder order = ChannelOrder.builder()
+                    .orderId("order-update")
+                    .sellerId("seller-A")
+                    .build();
+            order.getAudit().setUpdatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+
+            order.onUpdate();
+
+            assertThat(order.getAudit().getUpdatedAt()).isAfter(LocalDateTime.of(2026, 1, 1, 0, 0));
+        }
     }
 
     /* ===================================================================
@@ -115,12 +184,12 @@ class ChannelOrderEntityTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("ChannelOrderItem 엔티티")
+    @DisplayName("ChannelOrderItem 테스트")
     class ChannelOrderItemTests {
 
         // 작업 수량 기본값은 아직 피킹/포장 전 상태를 뜻한다.
         @Test
-        @DisplayName("Builder로 ChannelOrderItem을 생성하면 기본 수량 값이 0이다")
+        @DisplayName("수량 정보 없이 ChannelOrderItem을 생성했을 때 기본 수량 값은 0이어야 한다")
         void builder_defaultQuantities_areZero() {
             // given
             ChannelOrderItemId id = new ChannelOrderItemId("order-001", "sku-001");
@@ -145,12 +214,12 @@ class ChannelOrderEntityTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("ChannelApiId 복합 키")
+    @DisplayName("ChannelApiId 테스트")
     class ChannelApiIdTests {
 
         // 복합 키는 값 객체이므로 equals/hashCode 계약이 중요하다.
         @Test
-        @DisplayName("동일한 sellerId와 channelName이면 equals/hashCode가 같아야 한다")
+        @DisplayName("동일한 sellerId와 channelName이 주어지면 equals와 hashCode를 비교했을 때 같은 값이어야 한다")
         void equalIds_haveEqualHashCodes() {
             ChannelApiId id1 = new ChannelApiId("seller-A", "SHOPIFY");
             ChannelApiId id2 = new ChannelApiId("seller-A", "SHOPIFY");
@@ -160,7 +229,7 @@ class ChannelOrderEntityTest {
         }
 
         @Test
-        @DisplayName("다른 sellerId이면 equals가 false이다")
+        @DisplayName("다른 sellerId가 주어지면 equals를 비교했을 때 false여야 한다")
         void differentSellerId_notEqual() {
             ChannelApiId id1 = new ChannelApiId("seller-A", "SHOPIFY");
             ChannelApiId id2 = new ChannelApiId("seller-B", "SHOPIFY");
@@ -174,12 +243,12 @@ class ChannelOrderEntityTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("EasypostShipmentInvoice 엔티티")
+    @DisplayName("EasypostShipmentInvoice 테스트")
     class EasypostShipmentInvoiceTests {
 
         // 송장 엔티티는 추적/금액 필드 보존이 핵심이다.
         @Test
-        @DisplayName("Builder로 Invoice를 생성하면 invoiceNo와 carrierType이 올바르게 설정된다")
+        @DisplayName("송장 정보가 주어지면 EasypostShipmentInvoice를 생성했을 때 invoiceNo와 carrierType이 올바르게 설정되어야 한다")
         void builder_setsInvoiceFields() {
             // given & when
             EasypostShipmentInvoice invoice = EasypostShipmentInvoice.builder()
@@ -198,7 +267,7 @@ class ChannelOrderEntityTest {
         }
 
         @Test
-        @DisplayName("CarrierType 열거형은 USPS, UPS, FEDEX 세 가지 값을 가진다")
+        @DisplayName("CarrierType을 조회했을 때 USPS와 UPS와 FEDEX 값을 포함해야 한다")
         void carrierType_hasThreeValues() {
             assertThat(CarrierType.values()).containsExactlyInAnyOrder(
                     CarrierType.USPS, CarrierType.UPS, CarrierType.FEDEX
@@ -211,12 +280,12 @@ class ChannelOrderEntityTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("OrderChannel 열거형")
+    @DisplayName("OrderChannel 테스트")
     class OrderChannelTests {
 
         // 외부 저장값과 enum name 매핑이 일치해야 한다.
         @Test
-        @DisplayName("OrderChannel.SHOPIFY는 name()이 'SHOPIFY'여야 한다")
+        @DisplayName("OrderChannel.SHOPIFY를 조회했을 때 name 값은 SHOPIFY여야 한다")
         void shopify_name() {
             assertThat(OrderChannel.SHOPIFY.name()).isEqualTo("SHOPIFY");
         }

--- a/src/test/java/com/conk/integration/command/domain/aggregate/ChannelOrderItemTest.java
+++ b/src/test/java/com/conk/integration/command/domain/aggregate/ChannelOrderItemTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 // 주문 아이템은 복합 키와 기본 수량값이 올바르게 초기화되는지만 확인한다.
-@DisplayName("ChannelOrderItem Entity Tests")
+@DisplayName("ChannelOrderItem 테스트")
 class ChannelOrderItemTest {
 
     // 주문 아이디와 SKU가 함께 묶여 아이템 정체성이 유지되는지 본다.
     @Test
-    @DisplayName("빌더로 생성하면 복합키와 스냅샷 필드가 유지된다")
+    @DisplayName("주문 아이템 정보가 주어지면 엔티티를 생성했을 때 복합 키와 스냅샷 필드를 유지해야 한다")
     void builder_setsCompositeKeyAndSnapshotFields() {
         ChannelOrder order = ChannelOrder.builder()
                 .orderId("ORDER-ITEM-001")
@@ -35,7 +35,7 @@ class ChannelOrderItemTest {
 
     // picked/packed 수량은 작업 전 상태를 뜻하므로 기본값 0이 중요하다.
     @Test
-    @DisplayName("생성 시 pickedQuantity와 packedQuantity의 기본값은 0이다")
+    @DisplayName("수량 정보 없이 엔티티를 생성했을 때 pickedQuantity와 packedQuantity의 기본값은 0이어야 한다")
     void builder_defaultsPickedAndPackedQuantityToZero() {
         ChannelOrder order = ChannelOrder.builder()
                 .orderId("ORDER-ITEM-002")

--- a/src/test/java/com/conk/integration/command/domain/aggregate/ChannelOrderTest.java
+++ b/src/test/java/com/conk/integration/command/domain/aggregate/ChannelOrderTest.java
@@ -10,12 +10,12 @@ import java.time.LocalDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 // 주문 엔티티의 빌더 필드와 컬렉션 조작을 순수 객체 수준에서 검증한다.
-@DisplayName("ChannelOrder Entity Tests")
+@DisplayName("ChannelOrder 테스트")
 class ChannelOrderTest {
 
     // 배송지, 출고 시각, 송장 참조처럼 화면과 연동되는 필드가 빠짐없이 유지되어야 한다.
     @Test
-    @DisplayName("빌더로 생성하면 배송 정보와 송장 참조가 유지된다")
+    @DisplayName("주문 정보가 주어지면 엔티티를 생성했을 때 배송 정보와 송장 참조를 유지해야 한다")
     void builder_setsShippingAndInvoiceFields() {
         LocalDateTime orderedAt = LocalDateTime.of(2026, 3, 30, 10, 15);
 
@@ -45,7 +45,7 @@ class ChannelOrderTest {
 
     // addItem()은 연관관계 편의 메서드의 최소 동작만 보장하면 된다.
     @Test
-    @DisplayName("addItem()을 호출하면 주문 아이템 컬렉션에 항목이 추가된다")
+    @DisplayName("주문 아이템이 주어지면 addItem을 호출했을 때 주문 아이템 컬렉션에 항목이 추가되어야 한다")
     void addItem_addsItemToOrder() {
         ChannelOrder order = ChannelOrder.builder()
                 .orderId("ORDER-002")

--- a/src/test/java/com/conk/integration/command/domain/aggregate/EasypostShipmentInvoiceTest.java
+++ b/src/test/java/com/conk/integration/command/domain/aggregate/EasypostShipmentInvoiceTest.java
@@ -4,15 +4,17 @@ import com.conk.integration.command.domain.aggregate.enums.CarrierType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 // 송장 엔티티는 추적용 문자열 필드와 금액 필드 보존에 초점을 둔다.
-@DisplayName("EasypostShipmentInvoice Entity Tests")
+@DisplayName("EasypostShipmentInvoice 테스트")
 class EasypostShipmentInvoiceTest {
 
     // 출고 흐름에서 직접 소비되는 추적 URL과 시각 필드가 깨지지 않는지 확인한다.
     @Test
-    @DisplayName("빌더로 생성하면 배송 추적 관련 필드가 유지된다")
+    @DisplayName("송장 정보가 주어지면 엔티티를 생성했을 때 배송 추적 관련 필드를 유지해야 한다")
     void builder_setsTrackingAndIssueFields() {
         EasypostShipmentInvoice invoice = EasypostShipmentInvoice.builder()
                 .invoiceNo("INV-001")
@@ -35,7 +37,7 @@ class EasypostShipmentInvoiceTest {
 
     // 주소와 라벨 URL은 외부 API 호출에 그대로 전달될 수 있어 값 보존이 중요하다.
     @Test
-    @DisplayName("송장 주소와 라벨 URL을 개별 필드로 보존한다")
+    @DisplayName("송장 주소와 라벨 URL이 주어지면 엔티티를 생성했을 때 각 필드를 그대로 보존해야 한다")
     void builder_keepsAddressAndLabelUrl() {
         EasypostShipmentInvoice invoice = EasypostShipmentInvoice.builder()
                 .invoiceNo("INV-002")
@@ -47,5 +49,45 @@ class EasypostShipmentInvoiceTest {
 
         assertThat(invoice.getShipToAddress()).isEqualTo("456 Oak Ave, New York, NY");
         assertThat(invoice.getLabelFileUrl()).isEqualTo("https://label.easypost.com/INV-002.pdf");
+    }
+
+    @Test
+    @DisplayName("trackingCode가 주어지면 엔티티를 생성했을 때 trackingCode 필드를 보존해야 한다")
+    void builder_setsTrackingCode() {
+        EasypostShipmentInvoice invoice = EasypostShipmentInvoice.builder()
+                .invoiceNo("INV-003")
+                .trackingCode("TRK-003")
+                .carrierType(CarrierType.USPS)
+                .build();
+
+        assertThat(invoice.getTrackingCode()).isEqualTo("TRK-003");
+    }
+
+    @Test
+    @DisplayName("감사 필드가 없는 엔티티가 주어지면 onCreate를 호출했을 때 createdAt과 updatedAt을 채워야 한다")
+    void onCreate_setsAuditCreatedAtAndUpdatedAt() {
+        EasypostShipmentInvoice invoice = EasypostShipmentInvoice.builder()
+                .invoiceNo("INV-004")
+                .carrierType(CarrierType.USPS)
+                .build();
+
+        invoice.onCreate();
+
+        assertThat(invoice.getAudit().getCreatedAt()).isNotNull();
+        assertThat(invoice.getAudit().getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("감사 필드가 있는 엔티티가 주어지면 onUpdate를 호출했을 때 updatedAt을 갱신해야 한다")
+    void onUpdate_updatesAuditUpdatedAt() {
+        EasypostShipmentInvoice invoice = EasypostShipmentInvoice.builder()
+                .invoiceNo("INV-005")
+                .carrierType(CarrierType.USPS)
+                .build();
+        invoice.getAudit().setUpdatedAt(LocalDateTime.of(2026, 1, 1, 0, 0));
+
+        invoice.onUpdate();
+
+        assertThat(invoice.getAudit().getUpdatedAt()).isAfter(LocalDateTime.of(2026, 1, 1, 0, 0));
     }
 }

--- a/src/test/java/com/conk/integration/command/infrastructure/config/ShopifyPropertiesTest.java
+++ b/src/test/java/com/conk/integration/command/infrastructure/config/ShopifyPropertiesTest.java
@@ -1,0 +1,49 @@
+package com.conk.integration.command.infrastructure.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ShopifyProperties 테스트")
+class ShopifyPropertiesTest {
+
+    private final ShopifyProperties properties = new ShopifyProperties();
+
+    @Test
+    @DisplayName("유효한 Shopify storeName이 주어지면 기본 URL을 조회했을 때 myshopify 도메인을 반환해야 한다")
+    void getBaseUrl_returnsMyShopifyDomainForValidStoreName() {
+        assertThat(properties.getBaseUrl("johns-apparel"))
+                .isEqualTo("https://johns-apparel.myshopify.com");
+    }
+
+    @Test
+    @DisplayName("대문자와 앞뒤 공백이 포함된 storeName이 주어지면 기본 URL을 조회했을 때 소문자로 정규화된 myshopify 도메인을 반환해야 한다")
+    void getBaseUrl_normalizesStoreName() {
+        assertThat(properties.getBaseUrl("  ConkTest  "))
+                .isEqualTo("https://conktest.myshopify.com");
+    }
+
+    @Test
+    @DisplayName("전체 URL이 주어지면 기본 URL을 조회했을 때 예외를 발생시켜야 한다")
+    void getBaseUrl_throwsForFullUrlInput() {
+        assertThatThrownBy(() -> properties.getBaseUrl("https://evil.example"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("유효하지 않은 Shopify storeName 형식입니다");
+    }
+
+    @Test
+    @DisplayName("점이 포함된 storeName이 주어지면 기본 URL을 조회했을 때 예외를 발생시켜야 한다")
+    void getBaseUrl_throwsForDotInStoreName() {
+        assertThatThrownBy(() -> properties.getBaseUrl("evil.com"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("슬래시가 포함된 storeName이 주어지면 기본 URL을 조회했을 때 예외를 발생시켜야 한다")
+    void getBaseUrl_throwsForSlashInStoreName() {
+        assertThatThrownBy(() -> properties.getBaseUrl("abc/def"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/conk/integration/command/infrastructure/repository/ChannelApiRepositoryTest.java
+++ b/src/test/java/com/conk/integration/command/infrastructure/repository/ChannelApiRepositoryTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 // ChannelApiRepository는 복합 키 기반 JPA 동작만 좁게 검증한다.
 @DataJpaTest
 @ActiveProfiles("test")
-@DisplayName("ChannelApiRepository Tests")
+@DisplayName("ChannelApiRepository 테스트")
 class ChannelApiRepositoryTest {
 
     @Autowired
@@ -22,7 +22,7 @@ class ChannelApiRepositoryTest {
 
     // 복합 키 조회는 개별 채널 설정을 수정/조회하는 기본 동작이다.
     @Test
-    @DisplayName("복합 키로 findById() 조회 시 올바른 엔티티가 반환된다")
+    @DisplayName("복합 키가 주어지면 findById로 조회했을 때 올바른 엔티티를 반환해야 한다")
     void findById_withCompositeKey_returnsCorrectEntity() {
         ChannelApiId id = new ChannelApiId("seller-C", "SHOPIFY");
         channelApiRepository.save(

--- a/src/test/java/com/conk/integration/command/infrastructure/repository/ChannelOrderRepositoryTest.java
+++ b/src/test/java/com/conk/integration/command/infrastructure/repository/ChannelOrderRepositoryTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 // ChannelOrderRepository의 커스텀 조회와 JPA 매핑 동작을 분리해서 검증한다.
 @DataJpaTest
 @ActiveProfiles("test")
-@DisplayName("ChannelOrderRepository Tests")
+@DisplayName("ChannelOrderRepository 테스트")
 class ChannelOrderRepositoryTest {
 
     @Autowired
@@ -31,7 +31,7 @@ class ChannelOrderRepositoryTest {
 
     // sellerId 필터가 다른 셀러 주문을 섞어 반환하지 않는지 본다.
     @Test
-    @DisplayName("findBySellerId()는 해당 sellerId의 주문만 반환한다")
+    @DisplayName("판매자 ID가 주어지면 findBySellerId로 조회했을 때 해당 판매자의 주문만 반환해야 한다")
     void findBySellerId_returnsOnlyMatchingSeller() {
         ChannelOrder orderA1 = baseOrder("O-A-001", "seller-A");
         ChannelOrder orderA2 = baseOrder("O-A-002", "seller-A");
@@ -48,7 +48,7 @@ class ChannelOrderRepositoryTest {
 
     // existsById는 sync 로직의 중복 방지 분기에서 직접 사용된다.
     @Test
-    @DisplayName("existsById()는 저장된 주문 ID에 대해서만 true를 반환한다")
+    @DisplayName("주문 ID가 주어지면 existsById로 조회했을 때 저장된 주문에만 true를 반환해야 한다")
     void existsById_returnsExpectedBoolean() {
         channelOrderRepository.save(baseOrder("O-EXISTS-001", "seller-X"));
 
@@ -58,7 +58,7 @@ class ChannelOrderRepositoryTest {
 
     // 연관 아이템은 부모 주문 저장만으로 함께 영속화되어야 한다.
     @Test
-    @DisplayName("주문 저장 시 연관 아이템이 cascade로 함께 저장된다")
+    @DisplayName("주문과 주문 아이템이 함께 주어지면 주문을 저장했을 때 연관 아이템도 함께 저장해야 한다")
     void save_cascadesItems() {
         ChannelOrder order = baseOrder("ORDER-ITEM-001", "seller-001");
         order.addItem(buildItem(order, "SKU-A1", 3, "Product A"));
@@ -77,7 +77,7 @@ class ChannelOrderRepositoryTest {
 
     // 컬렉션에서 제거된 자식이 실제 DB에서도 삭제되는지 orphanRemoval을 검증한다.
     @Test
-    @DisplayName("아이템을 컬렉션에서 제거하고 저장하면 orphanRemoval로 삭제된다")
+    @DisplayName("주문 아이템을 컬렉션에서 제거하면 주문을 저장했을 때 orphanRemoval로 삭제해야 한다")
     void save_removesOrphanedItems() {
         ChannelOrder order = baseOrder("ORDER-ITEM-002", "seller-001");
         order.addItem(buildItem(order, "SKU-C1", 1, "Product C"));

--- a/src/test/java/com/conk/integration/command/infrastructure/repository/EasypostShipmentInvoiceRepositoryTest.java
+++ b/src/test/java/com/conk/integration/command/infrastructure/repository/EasypostShipmentInvoiceRepositoryTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 // 송장 리포지토리는 저장 후 재조회와 미존재 조회 동작을 최소 범위로 본다.
 @DataJpaTest
 @ActiveProfiles("test")
-@DisplayName("EasypostShipmentInvoiceRepository Tests")
+@DisplayName("EasypostShipmentInvoiceRepository 테스트")
 class EasypostShipmentInvoiceRepositoryTest {
 
     @Autowired
@@ -22,7 +22,7 @@ class EasypostShipmentInvoiceRepositoryTest {
 
     // 저장 후 재조회로 주요 추적/금액 필드가 DB round-trip 후에도 유지되는지 확인한다.
     @Test
-    @DisplayName("Invoice를 저장하고 invoiceNo로 조회하면 동일한 데이터가 반환된다")
+    @DisplayName("송장 정보가 주어지면 저장 후 invoiceNo로 조회했을 때 동일한 데이터를 반환해야 한다")
     void save_andFindById_returnsSameInvoice() {
         EasypostShipmentInvoice invoice = EasypostShipmentInvoice.builder()
                 .invoiceNo("INV-TEST-001")
@@ -44,7 +44,7 @@ class EasypostShipmentInvoiceRepositoryTest {
 
     // 미존재 송장 조회는 예외 대신 빈 Optional을 반환해야 서비스 분기가 단순하다.
     @Test
-    @DisplayName("존재하지 않는 invoiceNo로 조회하면 Optional.empty()가 반환된다")
+    @DisplayName("존재하지 않는 invoiceNo가 주어지면 조회했을 때 Optional.empty를 반환해야 한다")
     void findById_notExisting_returnsEmpty() {
         assertThat(invoiceRepository.findById("NOT-EXIST")).isEmpty();
     }

--- a/src/test/java/com/conk/integration/command/infrastructure/service/EasyPostApiClientTest.java
+++ b/src/test/java/com/conk/integration/command/infrastructure/service/EasyPostApiClientTest.java
@@ -3,6 +3,9 @@ package com.conk.integration.command.infrastructure.service;
 import com.conk.integration.command.application.dto.request.EasyPostCreateShipmentRequest;
 import com.conk.integration.command.application.dto.response.EasyPostShipmentResponse;
 import com.conk.integration.command.infrastructure.config.EasyPostProperties;
+import com.conk.integration.common.exception.BusinessException;
+import com.conk.integration.common.exception.ErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,11 +23,13 @@ import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
 // EasyPostApiClient가 URL, 인증 헤더, 응답 파싱을 올바르게 수행하는지 검증한다.
-@DisplayName("EasyPostApiClient 단위 테스트")
+@DisplayName("EasyPostApiClient 테스트")
 class EasyPostApiClientTest {
 
     private MockRestServiceServer mockServer;
@@ -52,7 +57,7 @@ class EasyPostApiClientTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] createShipment - 정상 응답 시 shipment id와 rates 반환")
+    @DisplayName("정상 응답이 주어지면 createShipment를 호출했을 때 shipment id와 rates를 반환해야 한다")
     void createShipment_returnsShipmentWithRates_whenSuccessful() {
         mockServer.expect(requestTo(BASE_URL + "/v2/shipments"))
                 .andExpect(method(HttpMethod.POST))
@@ -68,7 +73,7 @@ class EasyPostApiClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] createShipment - Basic Auth 헤더 포함 확인")
+    @DisplayName("요청 정보를 직렬화할 수 있으면 createShipment를 호출했을 때 Basic Auth 헤더를 포함해야 한다")
     void createShipment_includesBasicAuthHeader() {
         // EasyPost는 API key를 Basic Auth로 요구하므로 헤더 구성이 핵심이다.
         String expectedAuth = "Basic " + Base64.getEncoder().encodeToString(
@@ -84,7 +89,7 @@ class EasyPostApiClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] createShipment - rates가 빈 배열인 경우")
+    @DisplayName("운임 정보가 빈 배열인 응답이 주어지면 createShipment를 호출했을 때 빈 rates를 반환해야 한다")
     void createShipment_returnsEmptyRates_whenNoRatesAvailable() {
         String json = "{\"id\":\"shp_empty\",\"status\":\"created\",\"rates\":[]}";
         mockServer.expect(requestTo(BASE_URL + "/v2/shipments"))
@@ -97,7 +102,7 @@ class EasyPostApiClientTest {
     }
 
     @Test
-    @DisplayName("[예외] createShipment - 401 Unauthorized → HttpClientErrorException")
+    @DisplayName("401 응답이 주어지면 createShipment를 호출했을 때 HttpClientErrorException을 전파해야 한다")
     void createShipment_throws_whenUnauthorized() {
         mockServer.expect(requestTo(BASE_URL + "/v2/shipments"))
                 .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
@@ -109,7 +114,7 @@ class EasyPostApiClientTest {
     }
 
     @Test
-    @DisplayName("[예외] createShipment - 422 Unprocessable Entity → HttpClientErrorException")
+    @DisplayName("422 응답이 주어지면 createShipment를 호출했을 때 HttpClientErrorException을 전파해야 한다")
     void createShipment_throws_whenUnprocessableEntity() {
         mockServer.expect(requestTo(BASE_URL + "/v2/shipments"))
                 .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY));
@@ -121,7 +126,7 @@ class EasyPostApiClientTest {
     }
 
     @Test
-    @DisplayName("[예외] createShipment - 500 서버 오류 → HttpServerErrorException")
+    @DisplayName("500 응답이 주어지면 createShipment를 호출했을 때 HttpServerErrorException을 전파해야 한다")
     void createShipment_throws_whenServerError() {
         mockServer.expect(requestTo(BASE_URL + "/v2/shipments"))
                 .andRespond(withServerError());
@@ -130,12 +135,59 @@ class EasyPostApiClientTest {
                 .isInstanceOf(HttpServerErrorException.class);
     }
 
+    @Test
+    @DisplayName("shipment body가 null이면 createShipment를 호출했을 때 BusinessException(INT-002)를 발생시켜야 한다")
+    void createShipment_throwsWhenShipmentBodyIsNull() {
+        EasyPostCreateShipmentRequest request = EasyPostCreateShipmentRequest.builder().build();
+
+        assertThatThrownBy(() -> client.createShipment(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.SHIPMENT_BODY_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("응답 body가 null이면 createShipment를 호출했을 때 BusinessException(INT-303)을 발생시켜야 한다")
+    void createShipment_throwsWhenResponseBodyIsNull() {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        EasyPostApiClient localClient = new EasyPostApiClient(restTemplate, properties, new ObjectMapper());
+
+        given(restTemplate.exchange(
+                org.mockito.ArgumentMatchers.eq(properties.getShipmentsUrl()),
+                org.mockito.ArgumentMatchers.eq(HttpMethod.POST),
+                org.mockito.ArgumentMatchers.<org.springframework.http.HttpEntity<String>>any(),
+                org.mockito.ArgumentMatchers.eq(EasyPostShipmentResponse.class)
+        )).willReturn(org.springframework.http.ResponseEntity.<EasyPostShipmentResponse>ok(null));
+
+        assertThatThrownBy(() -> localClient.createShipment(buildRequest()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EASYPOST_EMPTY_RESPONSE);
+    }
+
+    @Test
+    @DisplayName("JSON 직렬화에 실패하면 createShipment를 호출했을 때 BusinessException(INT-304)을 발생시켜야 한다")
+    void createShipment_throwsSerializationFailedWhenJsonWriteFails() {
+        ObjectMapper failingMapper = new ObjectMapper() {
+            @Override
+            public String writeValueAsString(Object value) throws JsonProcessingException {
+                throw new JsonProcessingException("serialization failed") { };
+            }
+        };
+        EasyPostApiClient localClient = new EasyPostApiClient(new RestTemplate(), properties, failingMapper);
+
+        assertThatThrownBy(() -> localClient.createShipment(buildRequest()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EASYPOST_SERIALIZATION_FAILED);
+    }
+
     // ─────────────────────────────────────────────────────────
     // buyRate
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] buyRate - 정상 응답 시 label_url, tracking 반환")
+    @DisplayName("정상 응답이 주어지면 buyRate를 호출했을 때 labelUrl과 tracking 정보를 반환해야 한다")
     void buyRate_returnsShipmentWithLabelAndTracking_whenSuccessful() {
         String shipmentId = "shp_test_001";
         String rateId = "rate_001";
@@ -159,7 +211,7 @@ class EasyPostApiClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] buyRate - shipmentId가 URL에 올바르게 포함")
+    @DisplayName("shipmentId가 주어지면 buyRate를 호출했을 때 요청 URL에 shipmentId를 포함해야 한다")
     void buyRate_usesCorrectUrlWithShipmentId() {
         // buyRate는 shipmentId가 경로에 직접 들어가므로 URL 조합을 확인한다.
         String shipmentId = "shp_xyz_999";
@@ -172,13 +224,49 @@ class EasyPostApiClientTest {
     }
 
     @Test
-    @DisplayName("[예외] buyRate - 500 서버 오류 → HttpServerErrorException")
+    @DisplayName("500 응답이 주어지면 buyRate를 호출했을 때 HttpServerErrorException을 전파해야 한다")
     void buyRate_throws_whenServerError() {
         mockServer.expect(requestTo(BASE_URL + "/v2/shipments/shp_001/buy"))
                 .andRespond(withServerError());
 
         assertThatThrownBy(() -> client.buyRate("shp_001", "rate_001"))
                 .isInstanceOf(HttpServerErrorException.class);
+    }
+
+    @Test
+    @DisplayName("응답 body가 null이면 buyRate를 호출했을 때 BusinessException(INT-303)을 발생시켜야 한다")
+    void buyRate_throwsWhenResponseBodyIsNull() {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        EasyPostApiClient localClient = new EasyPostApiClient(restTemplate, properties, new ObjectMapper());
+
+        given(restTemplate.exchange(
+                org.mockito.ArgumentMatchers.eq(properties.getBuyRateUrl("shp_001")),
+                org.mockito.ArgumentMatchers.eq(HttpMethod.POST),
+                org.mockito.ArgumentMatchers.<org.springframework.http.HttpEntity<String>>any(),
+                org.mockito.ArgumentMatchers.eq(EasyPostShipmentResponse.class)
+        )).willReturn(org.springframework.http.ResponseEntity.<EasyPostShipmentResponse>ok(null));
+
+        assertThatThrownBy(() -> localClient.buyRate("shp_001", "rate_001"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EASYPOST_EMPTY_RESPONSE);
+    }
+
+    @Test
+    @DisplayName("JSON 직렬화에 실패하면 buyRate를 호출했을 때 BusinessException(INT-304)을 발생시켜야 한다")
+    void buyRate_throwsSerializationFailedWhenJsonWriteFails() {
+        ObjectMapper failingMapper = new ObjectMapper() {
+            @Override
+            public String writeValueAsString(Object value) throws JsonProcessingException {
+                throw new JsonProcessingException("serialization failed") { };
+            }
+        };
+        EasyPostApiClient localClient = new EasyPostApiClient(new RestTemplate(), properties, failingMapper);
+
+        assertThatThrownBy(() -> localClient.buyRate("shp_001", "rate_001"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EASYPOST_SERIALIZATION_FAILED);
     }
 
     // ─────────────────────────────────────────────────────────

--- a/src/test/java/com/conk/integration/command/infrastructure/service/ShopifyFulfillmentApiClientTest.java
+++ b/src/test/java/com/conk/integration/command/infrastructure/service/ShopifyFulfillmentApiClientTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
 // Shopify 출고 API 클라이언트의 URL, 헤더, 응답 파싱을 검증한다.
-@DisplayName("ShopifyFulfillmentApiClient 단위 테스트")
+@DisplayName("ShopifyFulfillmentApiClient 테스트")
 class ShopifyFulfillmentApiClientTest {
 
     private MockRestServiceServer mockServer;
@@ -50,7 +50,7 @@ class ShopifyFulfillmentApiClientTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] fulfillment 생성 성공 - fulfillment id 반환")
+    @DisplayName("정상 응답이 주어지면 fulfillment 생성을 요청했을 때 fulfillment id를 반환해야 한다")
     void createFulfillment_returnsFulfillmentId_whenSuccessful() {
         mockServer.expect(requestTo(fulfillmentsUrl(SHOPIFY_ORDER_ID)))
                 .andExpect(method(HttpMethod.POST))
@@ -63,7 +63,7 @@ class ShopifyFulfillmentApiClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] X-Shopify-Access-Token 헤더 포함 확인")
+    @DisplayName("인증 정보가 주어지면 fulfillment 생성을 요청했을 때 X-Shopify-Access-Token 헤더를 포함해야 한다")
     void createFulfillment_includesAccessTokenHeader() {
         mockServer.expect(requestTo(fulfillmentsUrl(SHOPIFY_ORDER_ID)))
                 .andExpect(method(HttpMethod.POST))
@@ -75,7 +75,7 @@ class ShopifyFulfillmentApiClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] URL에 orderId가 올바르게 포함된다")
+    @DisplayName("주문 번호가 주어지면 fulfillment 생성을 요청했을 때 요청 URL에 orderId를 포함해야 한다")
     void createFulfillment_usesCorrectUrlWithOrderId() {
         String anotherOrderId = "9999999999";
         mockServer.expect(requestTo(fulfillmentsUrl(anotherOrderId)))
@@ -87,7 +87,7 @@ class ShopifyFulfillmentApiClientTest {
     }
 
     @Test
-    @DisplayName("[예외] 401 Unauthorized → HttpClientErrorException")
+    @DisplayName("401 응답이 주어지면 fulfillment 생성을 요청했을 때 HttpClientErrorException을 전파해야 한다")
     void createFulfillment_throws_whenUnauthorized() {
         mockServer.expect(requestTo(fulfillmentsUrl(SHOPIFY_ORDER_ID)))
                 .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
@@ -99,7 +99,7 @@ class ShopifyFulfillmentApiClientTest {
     }
 
     @Test
-    @DisplayName("[예외] 422 Unprocessable Entity → HttpClientErrorException")
+    @DisplayName("422 응답이 주어지면 fulfillment 생성을 요청했을 때 HttpClientErrorException을 전파해야 한다")
     void createFulfillment_throws_whenUnprocessableEntity() {
         mockServer.expect(requestTo(fulfillmentsUrl(SHOPIFY_ORDER_ID)))
                 .andRespond(withStatus(HttpStatus.UNPROCESSABLE_ENTITY));
@@ -111,7 +111,7 @@ class ShopifyFulfillmentApiClientTest {
     }
 
     @Test
-    @DisplayName("[예외] 500 서버 오류 → HttpServerErrorException")
+    @DisplayName("500 응답이 주어지면 fulfillment 생성을 요청했을 때 HttpServerErrorException을 전파해야 한다")
     void createFulfillment_throws_whenServerError() {
         mockServer.expect(requestTo(fulfillmentsUrl(SHOPIFY_ORDER_ID)))
                 .andRespond(withServerError());
@@ -125,7 +125,7 @@ class ShopifyFulfillmentApiClientTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] GraphQL 엔드포인트로 POST 요청을 전송한다")
+    @DisplayName("일괄 fulfillment 대상이 주어지면 일괄 fulfillment 생성을 요청했을 때 GraphQL 엔드포인트로 POST 요청을 전송해야 한다")
     void createBulkFulfillment_postsToGraphQLUrl() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andExpect(method(HttpMethod.POST))
@@ -141,7 +141,7 @@ class ShopifyFulfillmentApiClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 여러 건의 target이 있어도 1회 호출로 처리된다")
+    @DisplayName("여러 대상이 주어지면 일괄 fulfillment 생성을 요청했을 때 한 번의 API 호출로 처리해야 한다")
     void createBulkFulfillment_sendsOneRequestForMultipleTargets() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andExpect(method(HttpMethod.POST))
@@ -158,7 +158,7 @@ class ShopifyFulfillmentApiClientTest {
     }
 
     @Test
-    @DisplayName("[예외] 빈 타겟 리스트로도 GraphQL 엔드포인트에 요청을 전송한다")
+    @DisplayName("빈 대상 목록이 주어지면 일괄 fulfillment 생성을 요청했을 때도 GraphQL 엔드포인트에 요청을 전송해야 한다")
     void createBulkFulfillment_withEmptyTargetList_stillCallsGraphQL() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andExpect(method(HttpMethod.POST))
@@ -170,7 +170,7 @@ class ShopifyFulfillmentApiClientTest {
     }
 
     @Test
-    @DisplayName("[예외] GraphQL 엔드포인트 401 → HttpClientErrorException")
+    @DisplayName("GraphQL 엔드포인트에서 401 응답이 주어지면 일괄 fulfillment 생성을 요청했을 때 HttpClientErrorException을 전파해야 한다")
     void createBulkFulfillment_throws_whenUnauthorized() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
@@ -183,7 +183,7 @@ class ShopifyFulfillmentApiClientTest {
     }
 
     @Test
-    @DisplayName("[예외] GraphQL 엔드포인트 500 → HttpServerErrorException")
+    @DisplayName("GraphQL 엔드포인트에서 500 응답이 주어지면 일괄 fulfillment 생성을 요청했을 때 HttpServerErrorException을 전파해야 한다")
     void createBulkFulfillment_throws_whenServerError() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withServerError());

--- a/src/test/java/com/conk/integration/command/infrastructure/service/ShopifyOrderClientTest.java
+++ b/src/test/java/com/conk/integration/command/infrastructure/service/ShopifyOrderClientTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
 // Shopify GraphQL 주문 조회 클라이언트의 URL, 헤더, 응답 파싱을 검증한다.
-@DisplayName("ShopifyOrderClient 단위 테스트")
+@DisplayName("ShopifyOrderClient 테스트")
 class ShopifyOrderClientTest {
 
     private MockRestServiceServer mockServer;
@@ -48,7 +48,7 @@ class ShopifyOrderClientTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] GraphQL 엔드포인트로 POST 요청을 전송한다")
+    @DisplayName("인증 정보가 주어지면 주문 목록을 조회했을 때 GraphQL 엔드포인트로 POST 요청을 전송해야 한다")
     void getOrders_postsToGraphQLUrl() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andExpect(method(HttpMethod.POST))
@@ -60,7 +60,7 @@ class ShopifyOrderClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] X-Shopify-Access-Token 헤더를 포함한다")
+    @DisplayName("인증 정보가 주어지면 주문 목록을 조회했을 때 X-Shopify-Access-Token 헤더를 포함해야 한다")
     void getOrders_includesAccessTokenHeader() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andExpect(header("X-Shopify-Access-Token", ACCESS_TOKEN))
@@ -71,7 +71,7 @@ class ShopifyOrderClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 응답에서 OrderNode 목록을 정확히 파싱한다")
+    @DisplayName("주문 응답이 주어지면 주문 목록을 조회했을 때 OrderNode 목록을 정확히 파싱해야 한다")
     void getOrders_parsesOrderNodesCorrectly() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withSuccess(ordersResponseJson(), MediaType.APPLICATION_JSON));
@@ -86,7 +86,7 @@ class ShopifyOrderClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] fulfillmentOrders GID가 응답에 포함된다")
+    @DisplayName("fulfillmentOrders가 포함된 응답이 주어지면 주문 목록을 조회했을 때 fulfillmentOrders GID를 파싱해야 한다")
     void getOrders_parsesFulfillmentOrderId() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withSuccess(ordersResponseJson(), MediaType.APPLICATION_JSON));
@@ -101,7 +101,7 @@ class ShopifyOrderClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 주문이 없으면 빈 리스트를 반환한다")
+    @DisplayName("주문이 없는 응답이 주어지면 주문 목록을 조회했을 때 빈 리스트를 반환해야 한다")
     void getOrders_returnsEmptyList_whenNoOrders() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withSuccess(emptyOrdersResponseJson(), MediaType.APPLICATION_JSON));
@@ -116,7 +116,7 @@ class ShopifyOrderClientTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[예외] API body가 null이면 BusinessException(INT-301)")
+    @DisplayName("API body가 null이면 주문 목록을 조회했을 때 BusinessException(INT-301)을 발생시켜야 한다")
     void getOrders_throwsWhenResponseBodyIsNull() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
@@ -126,7 +126,7 @@ class ShopifyOrderClientTest {
     }
 
     @Test
-    @DisplayName("[예외] data 필드가 null이면 BusinessException(INT-301)")
+    @DisplayName("data 필드가 null이면 주문 목록을 조회했을 때 BusinessException(INT-301)을 발생시켜야 한다")
     void getOrders_throwsWhenDataIsNull() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withSuccess("{\"data\": null}", MediaType.APPLICATION_JSON));
@@ -136,7 +136,7 @@ class ShopifyOrderClientTest {
     }
 
     @Test
-    @DisplayName("[예외] orders 필드가 null이면 BusinessException(INT-301)")
+    @DisplayName("orders 필드가 null이면 주문 목록을 조회했을 때 BusinessException(INT-301)을 발생시켜야 한다")
     void getOrders_throwsWhenOrdersIsNull() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withSuccess("{\"data\": {\"orders\": null}}", MediaType.APPLICATION_JSON));
@@ -146,7 +146,7 @@ class ShopifyOrderClientTest {
     }
 
     @Test
-    @DisplayName("[예외] 401 Unauthorized → HttpClientErrorException")
+    @DisplayName("401 응답이 주어지면 주문 목록을 조회했을 때 HttpClientErrorException을 전파해야 한다")
     void getOrders_throws_whenUnauthorized() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
@@ -158,7 +158,7 @@ class ShopifyOrderClientTest {
     }
 
     @Test
-    @DisplayName("[예외] 500 서버 오류 → HttpServerErrorException")
+    @DisplayName("500 응답이 주어지면 주문 목록을 조회했을 때 HttpServerErrorException을 전파해야 한다")
     void getOrders_throws_whenServerError() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withServerError());

--- a/src/test/java/com/conk/integration/common/ApiResponseTest.java
+++ b/src/test/java/com/conk/integration/common/ApiResponseTest.java
@@ -1,0 +1,28 @@
+package com.conk.integration.common;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ApiResponse 테스트")
+class ApiResponseTest {
+
+    @Test
+    @DisplayName("응답 데이터가 주어지면 ok를 호출했을 때 success가 true인 응답을 반환해야 한다")
+    void ok_returnsSuccessTrue() {
+        ApiResponse<String> response = ApiResponse.ok("payload");
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData()).isEqualTo("payload");
+    }
+
+    @Test
+    @DisplayName("응답 데이터가 주어지면 fail을 호출했을 때 success가 false인 응답을 반환해야 한다")
+    void fail_returnsSuccessFalse() {
+        ApiResponse<String> response = ApiResponse.fail("error");
+
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getData()).isEqualTo("error");
+    }
+}

--- a/src/test/java/com/conk/integration/e2e/api/EasyPostApiClientIntegrationTest.java
+++ b/src/test/java/com/conk/integration/e2e/api/EasyPostApiClientIntegrationTest.java
@@ -75,7 +75,7 @@ class EasyPostApiClientIntegrationTest {
 
     // 실제 샌드박스 shipment 생성 후 rate 목록이 내려오는지만 우선 검증한다.
     @Test
-    @DisplayName("[샌드박스] createShipment - 실제 API 호출 후 rates 반환 확인")
+    @DisplayName("실제 샌드박스 요청이 주어지면 createShipment를 호출했을 때 운임 정보를 반환해야 한다")
     void createShipment_returnsRates_fromSandbox() {
         EasyPostCreateShipmentRequest request = EasyPostCreateShipmentRequest.builder()
                 .shipment(EasyPostCreateShipmentRequest.ShipmentBody.builder()
@@ -99,7 +99,7 @@ class EasyPostApiClientIntegrationTest {
 
     // 생성-구매-저장 전체 흐름을 샌드박스 환경에서 한 번에 검증한다.
     @Test
-    @DisplayName("[샌드박스] createAndSaveInvoice - 전체 플로우 (createShipment → buyRate → DB 저장)")
+    @DisplayName("실제 샌드박스 요청이 주어지면 송장을 생성하고 저장했을 때 생성과 구매와 저장 흐름을 완료해야 한다")
     void createAndSaveInvoice_fullFlow_fromSandbox() {
         EasyPostCreateShipmentRequest request = EasyPostCreateShipmentRequest.builder()
                 .shipment(EasyPostCreateShipmentRequest.ShipmentBody.builder()
@@ -128,7 +128,7 @@ class EasyPostApiClientIntegrationTest {
     // 여러 주문에 대해 일괄 송장 발급이 정상 동작하는지 샌드박스에서 확인한다.
     @Test
     @Transactional
-    @DisplayName("[샌드박스] createAndSaveBulkInvoices - 주문 2건 일괄 발급 후 invoiceNo 반영 확인")
+    @DisplayName("실제 샌드박스 주문 2건이 주어지면 일괄 송장을 생성했을 때 주문에 invoiceNo를 반영해야 한다")
     void createAndSaveBulkInvoices_bulkFlow_fromSandbox() {
         // given — invoiceNo 없는 테스트 주문 2건을 DB에 저장
         channelOrderRepository.saveAndFlush(ChannelOrder.builder()

--- a/src/test/java/com/conk/integration/e2e/api/ShopifyApiClientIntegrationTest.java
+++ b/src/test/java/com/conk/integration/e2e/api/ShopifyApiClientIntegrationTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("sandbox")
 @SpringBootTest
 @ActiveProfiles("dev")
-@DisplayName("Shopify API 통합 테스트 (개발 스토어)")
+@DisplayName("Shopify API 통합 테스트")
 class ShopifyApiClientIntegrationTest {
 
     @Autowired
@@ -40,7 +40,7 @@ class ShopifyApiClientIntegrationTest {
 
     // 개발 스토어에서 실제 주문 목록을 읽고 최소 필드가 채워지는지 확인한다.
     @Test
-    @DisplayName("주문 목록 조회 - 실제 개발 스토어 API 호출")
+    @DisplayName("실제 개발 스토어 인증 정보가 주어지면 주문 목록을 조회했을 때 Shopify API 응답을 반환해야 한다")
     void getOrders_returnsOrdersFromDevStore() {
         // when
         List<ShopifyOrderResponse.OrderNode> orders = shopifyOrderClient.getOrders(storeName, accessToken);

--- a/src/test/java/com/conk/integration/e2e/flow/IntegrationTest.java
+++ b/src/test/java/com/conk/integration/e2e/flow/IntegrationTest.java
@@ -3,6 +3,7 @@ package com.conk.integration.e2e.flow;
 import com.conk.integration.command.application.dto.response.ChannelOrderSyncResponse;
 import com.conk.integration.command.domain.aggregate.*;
 import com.conk.integration.command.domain.aggregate.embeddable.ChannelApiId;
+import com.conk.integration.command.domain.aggregate.embeddable.ChannelOrderItemId;
 import com.conk.integration.command.domain.aggregate.enums.CarrierType;
 import com.conk.integration.command.domain.aggregate.enums.OrderChannel;
 import com.conk.integration.command.infrastructure.repository.*;
@@ -14,6 +15,7 @@ import com.conk.integration.command.infrastructure.service.ShopifyFulfillmentApi
 import com.conk.integration.command.application.dto.response.ShopifyOrderResponse;
 import com.conk.integration.query.dto.ShopifyCredentialDto;
 import com.conk.integration.query.service.ChannelApiQueryService;
+import com.conk.integration.query.service.ShopifyPingClient;
 import com.conk.integration.common.exception.BusinessException;
 import com.conk.integration.common.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -58,7 +60,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
-@DisplayName("[통합 테스트] 전체 시스템 데이터 흐름 검증 (Controller → Service → DB)")
+@DisplayName("전체 시스템 통합 테스트")
 class IntegrationTest {
 
     /* ---------- MockMvc (HTTP 계층 테스트) ---------- */
@@ -74,6 +76,9 @@ class IntegrationTest {
 
     @MockitoBean
     private ChannelApiQueryService channelApiQueryService;
+
+    @MockitoBean
+    private ShopifyPingClient shopifyPingClient;
 
     /* ---------- 실제 Bean ---------- */
     @Autowired
@@ -99,12 +104,12 @@ class IntegrationTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("ShopifyOrderSyncService 통합 — Shopify API 응답이 DB에 저장된다")
+    @DisplayName("Shopify 주문 동기화 통합 테스트")
     class SyncOrdersIntegrationTests {
 
         // 외부 주문 응답이 실제 DB 저장으로 이어지는지 본다.
         @Test
-        @DisplayName("syncOrders() — Shopify 주문 2건 반환 시 DB에 2건이 저장된다")
+        @DisplayName("Shopify 주문 2건이 주어지면 주문 동기화를 수행했을 때 DB에 2건을 저장해야 한다")
         void syncOrders_persistsTwoOrders() {
             // given
             ShopifyOrderResponse.OrderNode dto1 = buildShopifyOrderNode(9001L, "#9001", "Alice", "100 Main St");
@@ -124,7 +129,7 @@ class IntegrationTest {
         }
 
         @Test
-        @DisplayName("syncOrders() — 이미 저장된 주문은 중복 저장되지 않는다 (멱등성)")
+        @DisplayName("이미 저장된 주문이 다시 주어지면 주문 동기화를 수행했을 때 중복 저장하지 않아야 한다")
         void syncOrders_idempotent_doesNotDuplicateExistingOrder() {
             // 같은 주문이 다시 들어와도 DB 건수는 유지되어야 한다.
             // given — 주문 9003은 이미 DB에 존재
@@ -147,7 +152,7 @@ class IntegrationTest {
         }
 
         @Test
-        @DisplayName("syncOrders() — Shopify API 주문이 0건이면 DB에 아무 것도 저장되지 않는다")
+        @DisplayName("Shopify 주문이 비어 있으면 주문 동기화를 수행했을 때 DB에 저장하지 않아야 한다")
         void syncOrders_emptyResponse_savesNothing() {
             // given
             given(channelApiQueryService.findShopifyCredential("seller-integration-C")).willReturn(buildCredential());
@@ -162,7 +167,7 @@ class IntegrationTest {
         }
 
         @Test
-        @DisplayName("syncOrders() — lineItems가 있으면 channel_order_item도 함께 저장된다")
+        @DisplayName("lineItems가 포함된 주문이 주어지면 주문 동기화를 수행했을 때 주문 아이템도 함께 저장해야 한다")
         void syncOrders_persistsChannelOrderItems_whenLineItemsPresent() {
             // given
             ShopifyOrderResponse.OrderNode node = buildShopifyOrderNode(9010L, "#9010", "Diana", "400 Elm St");
@@ -184,7 +189,7 @@ class IntegrationTest {
         }
 
         @Test
-        @DisplayName("syncOrders() — 반환값에 savedCount와 skippedCount가 정확히 포함된다")
+        @DisplayName("기존 주문과 신규 주문이 함께 주어지면 주문 동기화를 수행했을 때 savedCount와 skippedCount를 정확히 반환해야 한다")
         void syncOrders_returnsCorrectSavedAndSkippedCount() {
             // given — 9020은 이미 DB에 존재, 9021은 신규
             channelOrderRepository.save(ChannelOrder.builder()
@@ -214,12 +219,12 @@ class IntegrationTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("ChannelFulfillmentDispatchService 통합 — DB 조회 후 Shopify API를 호출한다")
+    @DisplayName("fulfillment 전송 통합 테스트")
     class FulfillmentIntegrationTests {
 
         // DB에 필요한 데이터가 있으면 외부 fulfillment API까지 이어지는지 본다.
         @Test
-        @DisplayName("fulfill() — 주문과 invoice가 DB에 있으면 Shopify fulfillment API가 호출된다")
+        @DisplayName("주문과 송장 정보가 DB에 저장되어 있으면 fulfillment를 수행했을 때 Shopify fulfillment API를 호출해야 한다")
         void fulfill_callsShopifyApiWhenDataExists() {
             // given — Invoice와 ChannelOrder를 DB에 미리 저장
             invoiceRepository.save(EasypostShipmentInvoice.builder()
@@ -247,7 +252,7 @@ class IntegrationTest {
         }
 
         @Test
-        @DisplayName("fulfill() — DB에 주문이 없으면 BusinessException(INT-101)이 발생한다")
+        @DisplayName("DB에 주문이 없으면 fulfillment를 수행했을 때 BusinessException(INT-101)을 발생시켜야 한다")
         void fulfill_throwsWhenOrderNotInDb() {
             assertThatThrownBy(() -> fulfillmentDispatchService.fulfill("ORDER-NOT-EXIST"))
                     .isInstanceOf(BusinessException.class)
@@ -255,7 +260,7 @@ class IntegrationTest {
         }
 
         @Test
-        @DisplayName("fulfill() — 주문에 invoiceNo가 없으면 BusinessException(INT-202)이 발생한다")
+        @DisplayName("송장 번호가 없는 주문이 주어지면 fulfillment를 수행했을 때 BusinessException(INT-202)를 발생시켜야 한다")
         void fulfill_throwsWhenNoInvoiceInOrder() {
             // given — invoiceNo가 없는 주문
             channelOrderRepository.save(ChannelOrder.builder()
@@ -278,12 +283,12 @@ class IntegrationTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("GET /integrations/seller/orders — HTTP 전체 흐름 통합 테스트")
+    @DisplayName("주문 조회 HTTP 통합 테스트")
     class OrderQueryHttpIntegrationTests {
 
         // MyBatis 조회 결과가 HTTP 응답 JSON까지 전달되는 전체 경로를 확인한다.
         @Test
-        @DisplayName("DB에 주문이 있을 때 HTTP 요청으로 조회하면 200과 주문 데이터가 반환된다")
+        @DisplayName("DB에 주문이 저장되어 있으면 주문 조회를 요청했을 때 HTTP 200 응답과 주문 데이터를 반환해야 한다")
         void getOrders_e2e_returnsHttpOkWithData() throws Exception {
             // given — DB에 직접 저장 (JPA 영속성 컨텍스트를 DB와 동기화하여 MyBatis에서 읽을 수 있게 flush 처리)
             channelOrderRepository.saveAndFlush(ChannelOrder.builder()
@@ -310,7 +315,7 @@ class IntegrationTest {
         }
 
         @Test
-        @DisplayName("DB에 주문이 없을 때 HTTP 요청으로 조회하면 200과 빈 배열이 반환된다")
+        @DisplayName("DB에 주문이 저장되어 있지 않으면 주문 조회를 요청했을 때 HTTP 200 응답과 빈 배열을 반환해야 한다")
         void getOrders_e2e_returnsEmptyWhenNoData() throws Exception {
             // when & then — 데이터 없는 sellerId로 조회
             mockMvc.perform(get("/integrations/seller/orders")
@@ -322,14 +327,14 @@ class IntegrationTest {
         }
 
         @Test
-        @DisplayName("X-Seller-Id 헤더 누락 시 HTTP 400이 반환된다")
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 주문 조회를 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void getOrders_e2e_missingHeader_returns400() throws Exception {
             mockMvc.perform(get("/integrations/seller/orders"))
                     .andExpect(status().isBadRequest());
         }
 
         @Test
-        @DisplayName("invoiceNo가 있는 주문 조회 시 status가 PROCESSING으로 반환된다")
+        @DisplayName("송장 번호가 있는 주문이 저장되어 있으면 주문 조회를 요청했을 때 PROCESSING 상태를 반환해야 한다")
         void getOrders_e2e_processingStatusWhenInvoiceExists() throws Exception {
             // given — DB에 직접 저장하고 flush 처리
             channelOrderRepository.saveAndFlush(ChannelOrder.builder()
@@ -355,12 +360,12 @@ class IntegrationTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("POST /integrations/seller/orders/sync — HTTP 전체 흐름 통합 테스트")
+    @DisplayName("주문 동기화 HTTP 통합 테스트")
     class SyncOrdersHttpIntegrationTests {
 
         // HTTP 요청 → Controller → DispatchService → SyncService → DB 저장 전체 흐름을 확인한다.
         @Test
-        @DisplayName("정상 요청 — HTTP 200과 savedCount/skippedCount가 반환된다")
+        @DisplayName("유효한 주문 동기화 요청이 주어지면 주문 동기화를 요청했을 때 HTTP 200 응답과 처리 건수를 반환해야 한다")
         void syncOrders_e2e_returnsHttpOkWithCounts() throws Exception {
             // given
             ShopifyOrderResponse.OrderNode node = buildShopifyOrderNode(8001L, "#8001", "Alice", "100 Main St");
@@ -382,7 +387,7 @@ class IntegrationTest {
         }
 
         @Test
-        @DisplayName("sync 후 DB에 주문이 실제로 저장된다")
+        @DisplayName("유효한 주문 동기화 요청이 주어지면 주문 동기화를 요청했을 때 DB에 주문을 저장해야 한다")
         void syncOrders_e2e_persistsOrderToDb() throws Exception {
             // given
             ShopifyOrderResponse.OrderNode node = buildShopifyOrderNode(8002L, "#8002", "Bob", "200 Oak Ave");
@@ -406,7 +411,7 @@ class IntegrationTest {
         }
 
         @Test
-        @DisplayName("채널 크리덴셜이 없는 셀러 요청 시 HTTP 404가 반환된다")
+        @DisplayName("채널 자격 증명이 없는 판매자 요청이 주어지면 주문 동기화를 요청했을 때 HTTP 404 응답을 반환해야 한다")
         void syncOrders_e2e_missingCredential_returns404() throws Exception {
             // given — 크리덴셜 조회 시 예외 발생 (등록되지 않은 셀러)
             given(channelApiQueryService.findShopifyCredential("seller-no-cred"))
@@ -422,13 +427,48 @@ class IntegrationTest {
         }
 
         @Test
-        @DisplayName("X-Seller-Id 헤더 누락 시 HTTP 400이 반환된다")
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 주문 동기화를 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void syncOrders_e2e_missingSellerIdHeader_returns400() throws Exception {
             mockMvc.perform(post("/integrations/seller/orders/sync")
                             .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
                             .content("{\"orderChannel\":\"SHOPIFY\"}"))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false));
+        }
+
+        @Test
+        @DisplayName("유효한 판매자 헤더와 채널 키가 주어지면 채널 기준 주문 동기화를 요청했을 때 HTTP 200 응답과 처리 건수를 반환해야 한다")
+        void syncOrdersByChannel_e2e_returnsHttpOkWithCounts() throws Exception {
+            ShopifyOrderResponse.OrderNode node = buildShopifyOrderNode(8101L, "#8101", "Grace", "700 Cedar St");
+            given(channelApiQueryService.findShopifyCredential("seller-http-channel-A")).willReturn(buildCredential());
+            given(shopifyOrderClient.getOrders(anyString(), anyString())).willReturn(List.of(node));
+
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/sync", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-http-channel-A"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.savedCount").value(1))
+                    .andExpect(jsonPath("$.data.skippedCount").value(0))
+                    .andExpect(jsonPath("$.data.orders[0].orderId").value("8101"));
+        }
+
+        @Test
+        @DisplayName("유효한 판매자 헤더와 채널 키가 주어지면 채널 기준 주문 동기화를 요청했을 때 DB에 주문을 저장해야 한다")
+        void syncOrdersByChannel_e2e_persistsOrderToDb() throws Exception {
+            ShopifyOrderResponse.OrderNode node = buildShopifyOrderNode(8102L, "#8102", "Henry", "800 Maple Ave");
+            node.setLineItems(buildLineItemConnection("SKU-HTTP-02", "Gadget C", 2, null));
+            given(channelApiQueryService.findShopifyCredential("seller-http-channel-B")).willReturn(buildCredential());
+            given(shopifyOrderClient.getOrders(anyString(), anyString())).willReturn(List.of(node));
+
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/sync", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-http-channel-B"))
+                    .andExpect(status().isOk());
+
+            channelOrderRepository.flush();
+            ChannelOrder saved = channelOrderRepository.findById("8102").orElseThrow();
+            assertThat(saved.getChannelOrderNo()).isEqualTo("#8102");
+            assertThat(saved.getItems()).hasSize(1);
+            assertThat(saved.getItems().get(0).getId().getSkuId()).isEqualTo("SKU-HTTP-02");
         }
     }
 
@@ -437,12 +477,12 @@ class IntegrationTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("ChannelApi DB 저장 및 조회 통합 테스트")
+    @DisplayName("채널 API 저장 및 조회 통합 테스트")
     class ChannelApiIntegrationTests {
 
         // 채널 연결 정보의 저장과 sellerId 기반 조회를 함께 검증한다.
         @Test
-        @DisplayName("ChannelApi 저장 후 findByIdSellerId()로 조회하면 정상적으로 반환된다")
+        @DisplayName("채널 API 정보를 저장하면 판매자 ID로 조회했을 때 저장한 채널 정보를 반환해야 한다")
         void saveAndFindChannelApi() {
             // given
             ChannelApiId id = new ChannelApiId("seller-intg", "SHOPIFY");
@@ -457,6 +497,156 @@ class IntegrationTest {
             assertThat(result).hasSize(1);
             assertThat(result.get(0).getId().getChannelName()).isEqualTo("SHOPIFY");
             assertThat(result.get(0).getChannelApi()).isEqualTo("shopify-api-token");
+        }
+
+        @Test
+        @DisplayName("채널 API 정보를 저장하면 저장했을 때 createdAt과 updatedAt을 자동으로 기록해야 한다")
+        void saveChannelApi_setsAuditFields() {
+            ChannelApi saved = channelApiRepository.saveAndFlush(
+                    ChannelApi.builder()
+                            .id(new ChannelApiId("seller-audit", "SHOPIFY"))
+                            .channelApi("audit-token")
+                            .storeName("audit-store")
+                            .build());
+
+            assertThat(saved.getAudit().getCreatedAt()).isNotNull();
+            assertThat(saved.getAudit().getUpdatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("기존 채널 API 정보를 수정하면 수정했을 때 updatedAt을 갱신해야 한다")
+        void updateChannelApi_updatesUpdatedAt() {
+            ChannelApi saved = channelApiRepository.saveAndFlush(
+                    ChannelApi.builder()
+                            .id(new ChannelApiId("seller-audit-update", "SHOPIFY"))
+                            .channelApi("old-token")
+                            .storeName("old-store")
+                            .build());
+            LocalDateTime createdAt = saved.getAudit().getCreatedAt();
+
+            saved.updateConnection("new-token", "new-store");
+            ChannelApi updated = channelApiRepository.saveAndFlush(saved);
+
+            assertThat(updated.getAudit().getCreatedAt()).isEqualTo(createdAt);
+            assertThat(updated.getAudit().getUpdatedAt()).isNotNull();
+            assertThat(updated.getAudit().getUpdatedAt()).isAfterOrEqualTo(createdAt);
+        }
+    }
+
+    @Nested
+    @DisplayName("셀러 채널 연결 HTTP 통합 테스트")
+    class ConnectSellerChannelHttpIntegrationTests {
+
+        @Test
+        @DisplayName("유효한 Shopify 연결 요청이 주어지면 채널 연결을 요청했을 때 HTTP 200 응답과 저장된 연결 정보를 반환해야 한다")
+        void connectSellerChannel_e2e_returnsSavedConnection() throws Exception {
+            given(shopifyPingClient.ping("my-shopify-store", "shpat_http_token")).willReturn(true);
+
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/connect", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-http-connect")
+                            .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "storeName":"my-shopify-store",
+                                      "channelApi":"shpat_http_token",
+                                      "storeAlias":"Shopify KR Store",
+                                      "contactEmail":"ops@example.com",
+                                      "syncMode":"AUTO"
+                                    }
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.channelName").value("SHOPIFY"))
+                    .andExpect(jsonPath("$.data.storeName").value("my-shopify-store"))
+                    .andExpect(jsonPath("$.data.channelApi").value("shpat_http_token"));
+
+            ChannelApi saved = channelApiRepository.findById(
+                    new ChannelApiId("seller-http-connect", "SHOPIFY")).orElseThrow();
+            assertThat(saved.getStoreName()).isEqualTo("my-shopify-store");
+            assertThat(saved.getChannelApi()).isEqualTo("shpat_http_token");
+        }
+
+        @Test
+        @DisplayName("기존 Shopify 연결 정보가 있으면 채널 연결을 다시 요청했을 때 row를 추가하지 않고 갱신해야 한다")
+        void connectSellerChannel_e2e_updatesExistingRow() throws Exception {
+            channelApiRepository.saveAndFlush(ChannelApi.builder()
+                    .id(new ChannelApiId("seller-http-update", "SHOPIFY"))
+                    .channelApi("old-token")
+                    .storeName("old-store")
+                    .build());
+            given(shopifyPingClient.ping("new-store", "new-token")).willReturn(true);
+
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/connect", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-http-update")
+                            .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {"storeName":"new-store","channelApi":"new-token"}
+                                    """))
+                    .andExpect(status().isOk());
+
+            List<ChannelApi> result = channelApiMapper.findByIdSellerId("seller-http-update");
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getStoreName()).isEqualTo("new-store");
+            assertThat(result.get(0).getChannelApi()).isEqualTo("new-token");
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 아이템 audit 통합 테스트")
+    class ChannelOrderItemAuditIntegrationTests {
+
+        @Test
+        @DisplayName("주문 아이템을 저장하면 저장했을 때 createdAt과 updatedAt을 자동으로 기록해야 한다")
+        void saveChannelOrderItem_setsAuditFields() {
+            ChannelOrder order = ChannelOrder.builder()
+                    .orderId("ORDER-ITEM-AUDIT-001")
+                    .channelOrderNo("#ITEM-001")
+                    .orderChannel(OrderChannel.SHOPIFY)
+                    .sellerId("seller-item-audit")
+                    .build();
+            ChannelOrderItem item = ChannelOrderItem.builder()
+                    .id(new ChannelOrderItemId("ORDER-ITEM-AUDIT-001", "SKU-001"))
+                    .channelOrder(order)
+                    .quantity(2)
+                    .productNameSnapshot("상품 A")
+                    .build();
+            order.addItem(item);
+
+            ChannelOrder saved = channelOrderRepository.saveAndFlush(order);
+
+            assertThat(saved.getItems()).hasSize(1);
+            assertThat(saved.getItems().get(0).getAudit().getCreatedAt()).isNotNull();
+            assertThat(saved.getItems().get(0).getAudit().getUpdatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("기존 주문 아이템을 수정하면 수정했을 때 updatedAt을 갱신해야 한다")
+        void updateChannelOrderItem_updatesUpdatedAt() {
+            ChannelOrder order = ChannelOrder.builder()
+                    .orderId("ORDER-ITEM-AUDIT-002")
+                    .channelOrderNo("#ITEM-002")
+                    .orderChannel(OrderChannel.SHOPIFY)
+                    .sellerId("seller-item-audit")
+                    .build();
+            ChannelOrderItem item = ChannelOrderItem.builder()
+                    .id(new ChannelOrderItemId("ORDER-ITEM-AUDIT-002", "SKU-002"))
+                    .channelOrder(order)
+                    .quantity(1)
+                    .productNameSnapshot("상품 B")
+                    .build();
+            order.addItem(item);
+            channelOrderRepository.saveAndFlush(order);
+
+            ChannelOrder saved = channelOrderRepository.findById("ORDER-ITEM-AUDIT-002").orElseThrow();
+            ChannelOrderItem savedItem = saved.getItems().get(0);
+            LocalDateTime createdAt = savedItem.getAudit().getCreatedAt();
+
+            savedItem.updateProductNameSnapshot("상품 B 수정");
+            channelOrderRepository.saveAndFlush(saved);
+
+            assertThat(savedItem.getAudit().getCreatedAt()).isEqualTo(createdAt);
+            assertThat(savedItem.getAudit().getUpdatedAt()).isNotNull();
+            assertThat(savedItem.getAudit().getUpdatedAt()).isAfterOrEqualTo(createdAt);
         }
     }
 

--- a/src/test/java/com/conk/integration/query/controller/IntegrationQueryControllerTest.java
+++ b/src/test/java/com/conk/integration/query/controller/IntegrationQueryControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * - 검증 항목: HTTP 상태 코드, 응답 JSON 구조, 헤더 처리 여부
  */
 @WebMvcTest(IntegrationQueryController.class)
-@DisplayName("[Controller] IntegrationQueryController 슬라이스 테스트")
+@DisplayName("IntegrationQueryController 테스트")
 class IntegrationQueryControllerTest {
 
     @Autowired
@@ -55,12 +55,12 @@ class IntegrationQueryControllerTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("GET /integrations/seller/channels — 채널 카드 조회 (INT-001)")
+    @DisplayName("채널 카드 조회 테스트")
     class GetSellerChannelCardsTests {
 
         // 헤더 입력과 응답 JSON 구조가 계약대로 유지되는지 확인한다.
         @Test
-        @DisplayName("정상 요청 — HTTP 200과 success:true, 채널 카드 목록이 반환된다")
+        @DisplayName("유효한 판매자 헤더가 주어지면 채널 카드 조회를 요청했을 때 HTTP 200 응답과 채널 카드 목록을 반환해야 한다")
         void getSellerChannelCards_returnsOk() throws Exception {
             // given
             SellerChannelCardDto card = new SellerChannelCardDto();
@@ -88,7 +88,7 @@ class IntegrationQueryControllerTest {
         }
 
         @Test
-        @DisplayName("정상 요청 — 채널 카드가 없을 때 빈 배열이 반환된다")
+        @DisplayName("조회 결과가 없으면 채널 카드 조회를 요청했을 때 HTTP 200 응답과 빈 배열을 반환해야 한다")
         void getSellerChannelCards_returnsEmptyList() throws Exception {
             // given
             given(channelCardQueryService.getChannelCards("seller-B")).willReturn(List.of());
@@ -103,7 +103,7 @@ class IntegrationQueryControllerTest {
         }
 
         @Test
-        @DisplayName("X-Seller-Id 헤더가 없으면 HTTP 400이 반환된다")
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 채널 카드 조회를 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void getSellerChannelCards_missingHeader_returns400() throws Exception {
             // when & then — 요청 헤더 없이 호출
             mockMvc.perform(get("/integrations/seller/channels"))
@@ -111,7 +111,7 @@ class IntegrationQueryControllerTest {
         }
 
         @Test
-        @DisplayName("Service가 BusinessException(INT-001) 던지면 HTTP 400이 반환된다")
+        @DisplayName("서비스에서 BusinessException(INT-001)이 발생하면 채널 카드 조회를 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void getSellerChannelCards_serviceThrowsIllegalArg_returns400() throws Exception {
             // given
             given(channelCardQueryService.getChannelCards(""))
@@ -127,7 +127,7 @@ class IntegrationQueryControllerTest {
         }
 
         @Test
-        @DisplayName("여러 채널 카드가 있을 때 모두 반환된다")
+        @DisplayName("여러 채널 카드가 있으면 채널 카드 조회를 요청했을 때 모든 채널 카드를 반환해야 한다")
         void getSellerChannelCards_multipleCards() throws Exception {
             // 배열 응답에서 다건 직렬화가 정상 동작하는지 본다.
             // given
@@ -155,11 +155,11 @@ class IntegrationQueryControllerTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("GET /integrations/seller/channels/{channelKey} — 채널 연결 상세 조회")
+    @DisplayName("채널 연결 상세 조회 테스트")
     class GetSellerChannelDetailTests {
 
         @Test
-        @DisplayName("정상 요청 — HTTP 200과 채널 연결 상세가 반환된다")
+        @DisplayName("유효한 판매자 헤더와 채널 키가 주어지면 채널 연결 상세 조회를 요청했을 때 HTTP 200 응답과 상세 정보를 반환해야 한다")
         void getSellerChannelDetail_returnsOk() throws Exception {
             SellerChannelDetailDto detail = new SellerChannelDetailDto(
                     "SHOPIFY",
@@ -180,14 +180,14 @@ class IntegrationQueryControllerTest {
         }
 
         @Test
-        @DisplayName("X-Seller-Id 헤더가 없으면 HTTP 400이 반환된다")
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 채널 연결 상세 조회를 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void getSellerChannelDetail_missingHeader_returns400() throws Exception {
             mockMvc.perform(get("/integrations/seller/channels/SHOPIFY"))
                     .andExpect(status().isBadRequest());
         }
 
         @Test
-        @DisplayName("연결 정보가 없으면 HTTP 404가 반환된다")
+        @DisplayName("연결 정보가 없으면 채널 연결 상세 조회를 요청했을 때 HTTP 404 응답을 반환해야 한다")
         void getSellerChannelDetail_notFound_returns404() throws Exception {
             given(channelDetailQueryService.getChannelDetail("seller-A", "SHOPIFY"))
                     .willThrow(new BusinessException(ErrorCode.CHANNEL_CONNECTION_NOT_FOUND));
@@ -206,12 +206,12 @@ class IntegrationQueryControllerTest {
      * =================================================================== */
 
     @Nested
-    @DisplayName("GET /integrations/seller/orders — 통합 주문 조회 (INT-002)")
+    @DisplayName("통합 주문 조회 테스트")
     class GetSellerChannelOrdersTests {
 
         // 주문 조회 응답의 대표 필드가 JSON으로 정확히 직렬화되는지 본다.
         @Test
-        @DisplayName("정상 요청 — HTTP 200과 주문 목록이 반환된다")
+        @DisplayName("유효한 판매자 헤더가 주어지면 통합 주문 조회를 요청했을 때 HTTP 200 응답과 주문 목록을 반환해야 한다")
         void getSellerChannelOrders_returnsOk() throws Exception {
             // given
             SellerChannelOrderDto order = SellerChannelOrderDto.builder()
@@ -244,7 +244,7 @@ class IntegrationQueryControllerTest {
         }
 
         @Test
-        @DisplayName("정상 요청 — 주문이 없을 때 빈 배열이 반환된다")
+        @DisplayName("주문이 없으면 통합 주문 조회를 요청했을 때 HTTP 200 응답과 빈 배열을 반환해야 한다")
         void getSellerChannelOrders_returnsEmptyList() throws Exception {
             // given
             given(channelOrderQueryService.getOrders("seller-B")).willReturn(List.of());
@@ -258,7 +258,7 @@ class IntegrationQueryControllerTest {
         }
 
         @Test
-        @DisplayName("X-Seller-Id 헤더가 없으면 HTTP 400이 반환된다")
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 통합 주문 조회를 요청했을 때 HTTP 400 응답을 반환해야 한다")
         void getSellerChannelOrders_missingHeader_returns400() throws Exception {
             // when & then
             mockMvc.perform(get("/integrations/seller/orders"))
@@ -266,7 +266,7 @@ class IntegrationQueryControllerTest {
         }
 
         @Test
-        @DisplayName("PROCESSING 상태의 주문도 올바르게 직렬화된다")
+        @DisplayName("PROCESSING 상태의 주문이 주어지면 통합 주문 조회를 요청했을 때 상태 값을 올바르게 직렬화해야 한다")
         void getSellerChannelOrders_processingStatus() throws Exception {
             // given
             SellerChannelOrderDto processingOrder = SellerChannelOrderDto.builder()
@@ -290,7 +290,7 @@ class IntegrationQueryControllerTest {
         }
 
         @Test
-        @DisplayName("응답의 최상위 success 필드가 항상 true이다")
+        @DisplayName("정상 요청이 주어지면 통합 주문 조회를 요청했을 때 응답 최상위 success 필드는 true여야 한다")
         void getSellerChannelOrders_successFieldIsTrue() throws Exception {
             // given
             given(channelOrderQueryService.getOrders("seller-D")).willReturn(List.of());

--- a/src/test/java/com/conk/integration/query/mapper/ChannelApiMapperTest.java
+++ b/src/test/java/com/conk/integration/query/mapper/ChannelApiMapperTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @ActiveProfiles("test")
 @Transactional
-@DisplayName("ChannelApiMapper Tests")
+@DisplayName("ChannelApiMapper 테스트")
 class ChannelApiMapperTest {
 
     @Autowired
@@ -29,7 +29,7 @@ class ChannelApiMapperTest {
 
     // 한 셀러에 여러 채널이 연결된 상황에서 sellerId 필터가 정확히 동작해야 한다.
     @Test
-    @DisplayName("findByIdSellerId()는 해당 sellerId의 채널 API만 반환한다")
+    @DisplayName("판매자 ID가 주어지면 findByIdSellerId로 조회했을 때 해당 판매자의 채널 API만 반환해야 한다")
     void findByIdSellerId_returnsMatchingChannelApis() {
         channelApiRepository.saveAllAndFlush(List.of(
                 ChannelApi.builder()
@@ -55,7 +55,7 @@ class ChannelApiMapperTest {
 
     // 연결 정보가 없는 셀러는 빈 결과로 처리되어야 조회 API가 단순해진다.
     @Test
-    @DisplayName("findByIdSellerId()는 일치하는 sellerId가 없으면 빈 리스트를 반환한다")
+    @DisplayName("일치하는 판매자 ID가 없으면 findByIdSellerId로 조회했을 때 빈 리스트를 반환해야 한다")
     void findByIdSellerId_returnsEmptyWhenNoMatch() {
         List<ChannelApi> result = channelApiMapper.findByIdSellerId("seller-NONE");
 
@@ -63,7 +63,7 @@ class ChannelApiMapperTest {
     }
 
     @Test
-    @DisplayName("findBySellerIdAndChannelName()는 sellerId와 channelName이 모두 일치하는 채널만 반환한다")
+    @DisplayName("판매자 ID와 채널명이 주어지면 findBySellerIdAndChannelName으로 조회했을 때 둘 다 일치하는 채널만 반환해야 한다")
     void findBySellerIdAndChannelName_returnsMatchingChannelApi() {
         channelApiRepository.saveAllAndFlush(List.of(
                 ChannelApi.builder()
@@ -92,7 +92,7 @@ class ChannelApiMapperTest {
     }
 
     @Test
-    @DisplayName("findBySellerIdAndChannelName()는 일치하는 채널이 없으면 null을 반환한다")
+    @DisplayName("일치하는 채널이 없으면 findBySellerIdAndChannelName으로 조회했을 때 null을 반환해야 한다")
     void findBySellerIdAndChannelName_returnsNullWhenNoMatch() {
         ChannelApi result = channelApiMapper.findBySellerIdAndChannelName("seller-NONE", "SHOPIFY");
 

--- a/src/test/java/com/conk/integration/query/mapper/ChannelOrderInvoiceMapperTest.java
+++ b/src/test/java/com/conk/integration/query/mapper/ChannelOrderInvoiceMapperTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-@DisplayName("ChannelOrderInvoiceMapper Tests")
+@DisplayName("ChannelOrderInvoiceMapper 테스트")
 class ChannelOrderInvoiceMapperTest {
 
     @Autowired
@@ -29,7 +29,7 @@ class ChannelOrderInvoiceMapperTest {
     private ChannelOrderRepository channelOrderRepository;
 
     @Test
-    @DisplayName("findOrdersWithoutInvoice — invoiceNo가 null인 주문만 반환된다")
+    @DisplayName("invoiceNo가 null인 주문이 주어지면 findOrdersWithoutInvoice로 조회했을 때 송장이 없는 주문만 반환해야 한다")
     void findOrdersWithoutInvoice_returnsOnlyNullInvoiceOrders() {
         channelOrderRepository.saveAndFlush(orderWithoutInvoice("ORD-NO-INV-001", "seller-A", "Alice"));
         channelOrderRepository.saveAndFlush(orderWithoutInvoice("ORD-NO-INV-002", "seller-A", "Bob"));
@@ -43,7 +43,7 @@ class ChannelOrderInvoiceMapperTest {
     }
 
     @Test
-    @DisplayName("findOrdersWithoutInvoice — 다른 sellerId의 주문은 반환되지 않는다")
+    @DisplayName("다른 판매자의 주문이 함께 있으면 findOrdersWithoutInvoice로 조회했을 때 해당 판매자 주문만 반환해야 한다")
     void findOrdersWithoutInvoice_doesNotReturnOtherSellerOrders() {
         channelOrderRepository.saveAndFlush(orderWithoutInvoice("ORD-SELLER-A-001", "seller-A", "Alice"));
         channelOrderRepository.saveAndFlush(orderWithoutInvoice("ORD-SELLER-B-001", "seller-B", "Bob"));
@@ -55,7 +55,7 @@ class ChannelOrderInvoiceMapperTest {
     }
 
     @Test
-    @DisplayName("findOrdersWithoutInvoice — 조회 대상이 없으면 빈 리스트를 반환한다")
+    @DisplayName("조회 대상이 없으면 findOrdersWithoutInvoice로 조회했을 때 빈 리스트를 반환해야 한다")
     void findOrdersWithoutInvoice_returnsEmptyList() {
         List<InvoiceTargetDto> result = channelOrderInvoiceMapper.findOrdersWithoutInvoice("seller-EMPTY");
 
@@ -63,7 +63,7 @@ class ChannelOrderInvoiceMapperTest {
     }
 
     @Test
-    @DisplayName("findOrdersWithoutInvoice — receiverName, shipToAddress1 필드가 올바르게 매핑된다")
+    @DisplayName("송장이 없는 주문이 주어지면 findOrdersWithoutInvoice로 조회했을 때 receiverName과 shipToAddress1을 올바르게 매핑해야 한다")
     void findOrdersWithoutInvoice_mapsFieldsCorrectly() {
         channelOrderRepository.saveAndFlush(ChannelOrder.builder()
                 .orderId("ORD-FIELD-001")

--- a/src/test/java/com/conk/integration/query/service/ChannelApiQueryServiceTest.java
+++ b/src/test/java/com/conk/integration/query/service/ChannelApiQueryServiceTest.java
@@ -1,0 +1,81 @@
+package com.conk.integration.query.service;
+
+import com.conk.integration.command.domain.aggregate.ChannelApi;
+import com.conk.integration.command.domain.aggregate.embeddable.ChannelApiId;
+import com.conk.integration.common.exception.BusinessException;
+import com.conk.integration.common.exception.ErrorCode;
+import com.conk.integration.query.dto.ShopifyCredentialDto;
+import com.conk.integration.query.mapper.ChannelApiMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChannelApiQueryService 테스트")
+class ChannelApiQueryServiceTest {
+
+    @Mock
+    private ChannelApiMapper channelApiMapper;
+
+    @InjectMocks
+    private ChannelApiQueryService service;
+
+    @Test
+    @DisplayName("Shopify 자격 증명이 존재하면 자격 증명을 조회했을 때 DTO를 반환해야 한다")
+    void findShopifyCredential_returnsCredentialWhenExists() {
+        ShopifyCredentialDto credential = new ShopifyCredentialDto();
+        credential.setStoreName("test-store");
+        credential.setAccessToken("test-token");
+        given(channelApiMapper.findShopifyCredential("seller-001")).willReturn(credential);
+
+        ShopifyCredentialDto result = service.findShopifyCredential("seller-001");
+
+        assertThat(result.getStoreName()).isEqualTo("test-store");
+        assertThat(result.getAccessToken()).isEqualTo("test-token");
+    }
+
+    @Test
+    @DisplayName("Shopify 자격 증명이 없으면 자격 증명을 조회했을 때 BusinessException(INT-103)을 발생시켜야 한다")
+    void findShopifyCredential_throwsWhenCredentialNotFound() {
+        given(channelApiMapper.findShopifyCredential("seller-001")).willReturn(null);
+
+        assertThatThrownBy(() -> service.findShopifyCredential("seller-001"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHANNEL_CREDENTIALS_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("채널 연결 정보가 존재하면 채널 연결 정보를 조회했을 때 엔티티를 반환해야 한다")
+    void findChannelApi_returnsChannelApiWhenExists() {
+        ChannelApi channelApi = ChannelApi.builder()
+                .id(new ChannelApiId("seller-001", "SHOPIFY"))
+                .channelApi("token-value")
+                .storeName("store-name")
+                .build();
+        given(channelApiMapper.findBySellerIdAndChannelName("seller-001", "SHOPIFY")).willReturn(channelApi);
+
+        ChannelApi result = service.findChannelApi("seller-001", "SHOPIFY");
+
+        assertThat(result.getId().getSellerId()).isEqualTo("seller-001");
+        assertThat(result.getId().getChannelName()).isEqualTo("SHOPIFY");
+    }
+
+    @Test
+    @DisplayName("채널 연결 정보가 없으면 채널 연결 정보를 조회했을 때 BusinessException(INT-404)를 발생시켜야 한다")
+    void findChannelApi_throwsWhenChannelConnectionNotFound() {
+        given(channelApiMapper.findBySellerIdAndChannelName("seller-001", "SHOPIFY")).willReturn(null);
+
+        assertThatThrownBy(() -> service.findChannelApi("seller-001", "SHOPIFY"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHANNEL_CONNECTION_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/conk/integration/query/service/QueryServiceTest.java
+++ b/src/test/java/com/conk/integration/query/service/QueryServiceTest.java
@@ -30,12 +30,12 @@ import static org.mockito.BDDMockito.given;
  * - MyBatis Mapper를 Mock으로 대체하여 Query Service 로직 자체에 집중
  */
 @ExtendWith(MockitoExtension.class)
-@DisplayName("[Service] Query Service 단위 테스트 (Mockito)")
+@DisplayName("QueryService 테스트")
 class QueryServiceTest {
 
     // 주문 목록 조회는 mapper 결과를 API 응답용 DTO로 후처리하는 책임에 집중한다.
     @Nested
-    @DisplayName("SellerChannelOrderQueryService")
+    @DisplayName("SellerChannelOrderQueryService 테스트")
     class SellerChannelOrderQueryServiceTests {
 
         @Mock
@@ -45,7 +45,7 @@ class QueryServiceTest {
         private SellerChannelOrderQueryService sellerChannelOrderQueryService;
 
         @Test
-        @DisplayName("getOrders() — Mapper 결과를 SellerChannelOrderDto 리스트로 변환해 반환한다")
+        @DisplayName("조회 결과가 주어지면 주문 목록을 조회했을 때 SellerChannelOrderDto 리스트로 변환해 반환해야 한다")
         void getOrders_returnsMappedDtos() {
             // 요약 문자열, 상태, 표시용 필드 변환이 한 번에 보이도록 대표 케이스를 만든다.
             SellerChannelOrderQueryResult raw = new SellerChannelOrderQueryResult();
@@ -74,7 +74,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("getOrders() — 빈 목록을 반환할 경우 빈 리스트가 반환된다")
+        @DisplayName("조회 결과가 빈 목록이면 주문 목록을 조회했을 때 빈 리스트를 반환해야 한다")
         void getOrders_returnsEmptyList_whenNoOrders() {
             // mapper가 빈 결과를 줄 때 서비스는 추가 후처리 없이 빈 컬렉션을 유지해야 한다.
             given(channelOrderMapper.findBySellerIdWithItemSummary("seller-B"))
@@ -86,7 +86,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("getOrders() — sellerId가 null이면 BusinessException을 던진다")
+        @DisplayName("sellerId가 null이면 주문 목록을 조회했을 때 BusinessException을 발생시켜야 한다")
         void getOrders_throwsWhenSellerIdIsNull() {
             // 조회 계층에서도 sellerId 검증을 먼저 수행한다.
             assertThatThrownBy(() -> sellerChannelOrderQueryService.getOrders(null))
@@ -95,7 +95,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("getOrders() — sellerId가 빈 문자열이면 BusinessException을 던진다")
+        @DisplayName("sellerId가 빈 문자열이면 주문 목록을 조회했을 때 BusinessException을 발생시켜야 한다")
         void getOrders_throwsWhenSellerIdIsBlank() {
             // 공백 문자열은 의미 있는 조회 키가 아니므로 즉시 차단한다.
             assertThatThrownBy(() -> sellerChannelOrderQueryService.getOrders("   "))
@@ -104,7 +104,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("buildItemsSummary() — itemCount가 1이면 첫 번째 상품명만 반환한다")
+        @DisplayName("itemCount가 1이면 상품 요약을 생성했을 때 첫 번째 상품명만 반환해야 한다")
         void buildItemsSummary_singleItem_returnsNameOnly() {
             // 단일 품목 주문은 요약 접미사를 붙이지 않는다.
             String result = sellerChannelOrderQueryService.buildItemsSummary("상품A", 1);
@@ -112,7 +112,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("buildItemsSummary() — itemCount가 여러 건이면 '이름 외 N건' 형식으로 반환한다")
+        @DisplayName("itemCount가 여러 건이면 상품 요약을 생성했을 때 이름 외 N건 형식으로 반환해야 한다")
         void buildItemsSummary_multipleItems_returnsSummary() {
             // 대표 상품명 + 나머지 개수 형식이 리스트 화면 규칙이다.
             String result = sellerChannelOrderQueryService.buildItemsSummary("상품A", 4);
@@ -120,7 +120,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("buildItemsSummary() — firstItemName이 null이면 빈 문자열을 반환한다")
+        @DisplayName("firstItemName이 null이면 상품 요약을 생성했을 때 빈 문자열을 반환해야 한다")
         void buildItemsSummary_nullName_returnsEmpty() {
             // 대표 상품명이 없으면 깨진 요약 문자열 대신 빈 문자열을 준다.
             String result = sellerChannelOrderQueryService.buildItemsSummary(null, 3);
@@ -128,7 +128,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("resolveStatus() — shippedAt이 있으면 SHIPPED를 반환한다")
+        @DisplayName("shippedAt이 있으면 주문 상태를 계산했을 때 SHIPPED를 반환해야 한다")
         void resolveStatus_returnsShipped_whenShippedAtExists() {
             // 출고 시각이 존재하면 송장 존재 여부보다 배송 완료 상태가 우선이다.
             assertThat(sellerChannelOrderQueryService.resolveStatus("INV-001", "2024-01-20"))
@@ -136,7 +136,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("resolveStatus() — invoiceNo만 있으면 PROCESSING을 반환한다")
+        @DisplayName("invoiceNo만 있으면 주문 상태를 계산했을 때 PROCESSING을 반환해야 한다")
         void resolveStatus_returnsProcessing_whenOnlyInvoiceExists() {
             // 송장은 발급됐지만 shippedAt이 없으면 처리 중으로 본다.
             assertThat(sellerChannelOrderQueryService.resolveStatus("INV-001", null))
@@ -144,7 +144,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("resolveStatus() — 모두 없으면 NEW를 반환한다")
+        @DisplayName("invoiceNo와 shippedAt이 모두 없으면 주문 상태를 계산했을 때 NEW를 반환해야 한다")
         void resolveStatus_returnsNew_whenBothNull() {
             // 송장과 출고 정보가 모두 없으면 신규 주문 상태다.
             assertThat(sellerChannelOrderQueryService.resolveStatus(null, null))
@@ -152,7 +152,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("resolveStatus() — shippedAt이 빈 문자열이면 invoiceNo 존재 여부로 판단한다")
+        @DisplayName("shippedAt이 빈 문자열이면 주문 상태를 계산했을 때 invoiceNo 존재 여부로 판단해야 한다")
         void resolveStatus_blankShippedAt_usesInvoiceNo() {
             // shippedAt이 blank면 배송 완료로 보지 않고 invoice 존재 여부로 상태를 결정한다.
             assertThat(sellerChannelOrderQueryService.resolveStatus("INV-001", ""))
@@ -162,7 +162,7 @@ class QueryServiceTest {
 
     // 채널 카드 조회는 mapper 결과에 라벨과 실시간 Shopify 연동 상태를 덧입히는 책임을 검증한다.
     @Nested
-    @DisplayName("SellerChannelCardQueryService")
+    @DisplayName("SellerChannelCardQueryService 테스트")
     class SellerChannelCardQueryServiceTests {
 
         @Mock
@@ -178,7 +178,7 @@ class QueryServiceTest {
         private SellerChannelCardQueryService sellerChannelCardQueryService;
 
         @Test
-        @DisplayName("getChannelCards() — Mapper 결과에 label이 후처리되어 반환된다")
+        @DisplayName("조회 결과가 주어지면 채널 카드 목록을 조회했을 때 label을 후처리해 반환해야 한다")
         void getChannelCards_setsLabel() {
             // key는 저장용 값이고 label은 화면 표시용 값이라 후처리가 필요하다.
             SellerChannelCardDto card = new SellerChannelCardDto();
@@ -197,7 +197,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("getChannelCards() — 여러 채널 카드가 있으면 각각 label이 변환된다")
+        @DisplayName("여러 채널 카드가 주어지면 채널 카드 목록을 조회했을 때 각 label을 변환해 반환해야 한다")
         void getChannelCards_multiplCards_allLabeled() {
             // 채널별 라벨 변환이 항목마다 독립적으로 적용되는지 확인한다.
             SellerChannelCardDto shopify = new SellerChannelCardDto();
@@ -218,7 +218,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("getChannelCards() — sellerId가 null이면 BusinessException을 던진다")
+        @DisplayName("sellerId가 null이면 채널 카드 목록을 조회했을 때 BusinessException을 발생시켜야 한다")
         void getChannelCards_throwsWhenSellerIdIsNull() {
             // 조회 계층에서도 sellerId 검증을 먼저 수행한다.
             assertThatThrownBy(() -> sellerChannelCardQueryService.getChannelCards(null))
@@ -227,7 +227,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("getChannelCards() — sellerId가 빈 문자열이면 BusinessException을 던진다")
+        @DisplayName("sellerId가 빈 문자열이면 채널 카드 목록을 조회했을 때 BusinessException을 발생시켜야 한다")
         void getChannelCards_throwsWhenSellerIdIsBlank() {
             // 공백 문자열은 의미 있는 조회 키가 아니므로 즉시 차단한다.
             assertThatThrownBy(() -> sellerChannelCardQueryService.getChannelCards("   "))
@@ -236,7 +236,7 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("toLabel() — 알려진 채널명을 올바른 표시 이름으로 변환한다")
+        @DisplayName("알려진 채널명이 주어지면 표시 이름으로 변환했을 때 올바른 값을 반환해야 한다")
         void toLabel_mapsKnownChannels() {
             // 주요 채널은 사용자가 읽기 쉬운 고정 라벨로 변환한다.
             assertThat(sellerChannelCardQueryService.toLabel("SHOPIFY")).isEqualTo("Shopify");
@@ -246,14 +246,14 @@ class QueryServiceTest {
         }
 
         @Test
-        @DisplayName("toLabel() — 알 수 없는 채널명이면 원래 문자열 그대로 반환한다")
+        @DisplayName("알 수 없는 채널명이 주어지면 표시 이름으로 변환했을 때 원래 문자열을 반환해야 한다")
         void toLabel_returnsOriginalForUnknown() {
             // 미등록 채널은 원본 값을 유지해야 신규 채널 추가 시에도 안전하다.
             assertThat(sellerChannelCardQueryService.toLabel("TIKTOK")).isEqualTo("TIKTOK");
         }
 
         @Test
-        @DisplayName("toLabel() — null이면 빈 문자열을 반환한다")
+        @DisplayName("채널명이 null이면 표시 이름으로 변환했을 때 빈 문자열을 반환해야 한다")
         void toLabel_returnsEmpty_whenNull() {
             // null key는 화면 표시 단계에서 빈 값으로 정리한다.
             assertThat(sellerChannelCardQueryService.toLabel(null)).isEmpty();

--- a/src/test/java/com/conk/integration/query/service/SellerChannelCardQueryServiceTest.java
+++ b/src/test/java/com/conk/integration/query/service/SellerChannelCardQueryServiceTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 // 채널 카드 조회 서비스의 입력 검증, 라벨 후처리, Shopify ping 연동 상태를 검증한다.
 @ExtendWith(MockitoExtension.class)
-@DisplayName("query.SellerChannelCardQueryService 단위 테스트")
+@DisplayName("SellerChannelCardQueryService 테스트")
 class SellerChannelCardQueryServiceTest {
 
     @Mock private SellerChannelCardMapper channelCardMapper;
@@ -38,7 +38,7 @@ class SellerChannelCardQueryServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] mapper 결과 반환 후 label 채움")
+    @DisplayName("채널 카드 조회 결과가 주어지면 채널 카드 목록을 조회했을 때 label을 채워 반환해야 한다")
     void getChannelCards_delegatesToMapper_andFillsLabel() {
         // mapper raw 값은 유지하고 label만 후처리되는지 확인한다.
         SellerChannelCardDto dto = buildCard("SHOPIFY", "ACTIVE", 3, 1, LocalDateTime.now());
@@ -54,7 +54,7 @@ class SellerChannelCardQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 빈 결과 → 빈 리스트 반환")
+    @DisplayName("채널 카드 조회 결과가 비어 있으면 채널 카드 목록을 조회했을 때 빈 리스트를 반환해야 한다")
     void getChannelCards_returnsEmpty_whenMapperReturnsEmpty() {
         given(channelCardMapper.findBySellerIdGroupedByChannel("seller-1")).willReturn(List.of());
 
@@ -65,7 +65,7 @@ class SellerChannelCardQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] ACTIVE syncStatus mapper 값 그대로 통과 (SHOPIFY 외 채널)")
+    @DisplayName("Shopify가 아닌 채널의 ACTIVE 상태가 주어지면 채널 카드 목록을 조회했을 때 syncStatus를 그대로 유지해야 한다")
     void getChannelCards_activeSyncStatus_preserved() {
         // SHOPIFY 이외 채널은 ping 없이 DB 값을 그대로 반환해야 한다.
         SellerChannelCardDto dto = buildCard("AMAZON", "ACTIVE", 0, 0, null);
@@ -75,7 +75,7 @@ class SellerChannelCardQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] PLANNED syncStatus mapper 값 그대로 통과")
+    @DisplayName("PLANNED 상태가 주어지면 채널 카드 목록을 조회했을 때 syncStatus를 그대로 유지해야 한다")
     void getChannelCards_plannedSyncStatus_preserved() {
         SellerChannelCardDto dto = buildCard("AMAZON", "PLANNED", 0, 0, null);
         given(channelCardMapper.findBySellerIdGroupedByChannel("seller-1")).willReturn(List.of(dto));
@@ -84,7 +84,7 @@ class SellerChannelCardQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] pendingOrders/todayImported/lastSyncedAt mapper 값 그대로")
+    @DisplayName("통계 필드가 주어지면 채널 카드 목록을 조회했을 때 mapper 값을 그대로 유지해야 한다")
     void getChannelCards_statisticFields_passedThrough() {
         // 숫자/시각 통계 필드는 가공 없이 그대로 노출되어야 한다.
         LocalDateTime lastSync = LocalDateTime.of(2026, 3, 19, 9, 10);
@@ -105,7 +105,7 @@ class SellerChannelCardQueryServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] SHOPIFY + ping 성공 → syncStatus = CONNECTED")
+    @DisplayName("Shopify 자격 증명이 있고 ping에 성공하면 채널 카드 목록을 조회했을 때 syncStatus를 CONNECTED로 반환해야 한다")
     void getChannelCards_shopify_pingSuccess_returnsConnected() {
         given(channelCardMapper.findBySellerIdGroupedByChannel("seller-1"))
                 .willReturn(List.of(buildCard("SHOPIFY", "ACTIVE", 0, 0, null)));
@@ -116,7 +116,7 @@ class SellerChannelCardQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] SHOPIFY + ping 실패 → syncStatus = DISCONNECTED")
+    @DisplayName("Shopify 자격 증명이 있고 ping에 실패하면 채널 카드 목록을 조회했을 때 syncStatus를 DISCONNECTED로 반환해야 한다")
     void getChannelCards_shopify_pingFail_returnsDisconnected() {
         given(channelCardMapper.findBySellerIdGroupedByChannel("seller-1"))
                 .willReturn(List.of(buildCard("SHOPIFY", "ACTIVE", 0, 0, null)));
@@ -127,7 +127,7 @@ class SellerChannelCardQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] SHOPIFY + 자격증명 없음 → syncStatus = NOT_CONFIGURED")
+    @DisplayName("Shopify 자격 증명이 없으면 채널 카드 목록을 조회했을 때 syncStatus를 NOT_CONFIGURED로 반환해야 한다")
     void getChannelCards_shopify_noCredentials_returnsNotConfigured() {
         given(channelCardMapper.findBySellerIdGroupedByChannel("seller-1"))
                 .willReturn(List.of(buildCard("SHOPIFY", "PLANNED", 0, 0, null)));
@@ -139,7 +139,7 @@ class SellerChannelCardQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] AMAZON 채널은 ping 미호출, DB syncStatus 유지")
+    @DisplayName("Amazon 채널이 주어지면 채널 카드 목록을 조회했을 때 ping을 호출하지 않고 syncStatus를 유지해야 한다")
     void getChannelCards_nonShopify_doesNotCallPing() {
         given(channelCardMapper.findBySellerIdGroupedByChannel("seller-1"))
                 .willReturn(List.of(buildCard("AMAZON", "PLANNED", 0, 0, null)));
@@ -150,7 +150,7 @@ class SellerChannelCardQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] SHOPIFY + AMAZON 혼합 시 SHOPIFY만 ping 1회 호출")
+    @DisplayName("Shopify와 Amazon 채널이 함께 주어지면 채널 카드 목록을 조회했을 때 Shopify에만 ping을 한 번 호출해야 한다")
     void getChannelCards_mixed_onlyShopifyCallsPing() {
         given(channelCardMapper.findBySellerIdGroupedByChannel("seller-1"))
                 .willReturn(List.of(
@@ -171,37 +171,37 @@ class SellerChannelCardQueryServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] toLabel: SHOPIFY → 'Shopify'")
+    @DisplayName("SHOPIFY가 주어지면 표시 이름으로 변환했을 때 Shopify를 반환해야 한다")
     void toLabel_shopify() {
         assertThat(service.toLabel("SHOPIFY")).isEqualTo("Shopify");
     }
 
     @Test
-    @DisplayName("[GREEN] toLabel: AMAZON → 'Amazon'")
+    @DisplayName("AMAZON이 주어지면 표시 이름으로 변환했을 때 Amazon을 반환해야 한다")
     void toLabel_amazon() {
         assertThat(service.toLabel("AMAZON")).isEqualTo("Amazon");
     }
 
     @Test
-    @DisplayName("[GREEN] toLabel: MANUAL → 'Manual'")
+    @DisplayName("MANUAL이 주어지면 표시 이름으로 변환했을 때 Manual을 반환해야 한다")
     void toLabel_manual() {
         assertThat(service.toLabel("MANUAL")).isEqualTo("Manual");
     }
 
     @Test
-    @DisplayName("[GREEN] toLabel: EXCEL → 'Excel'")
+    @DisplayName("EXCEL이 주어지면 표시 이름으로 변환했을 때 Excel을 반환해야 한다")
     void toLabel_excel() {
         assertThat(service.toLabel("EXCEL")).isEqualTo("Excel");
     }
 
     @Test
-    @DisplayName("[GREEN] toLabel: 알 수 없는 값 → 원본 그대로")
+    @DisplayName("알 수 없는 채널명이 주어지면 표시 이름으로 변환했을 때 원본 값을 반환해야 한다")
     void toLabel_unknown_returnsAsIs() {
         assertThat(service.toLabel("UNKNOWN_CHANNEL")).isEqualTo("UNKNOWN_CHANNEL");
     }
 
     @Test
-    @DisplayName("[GREEN] toLabel: null → 빈 문자열")
+    @DisplayName("채널명이 null이면 표시 이름으로 변환했을 때 빈 문자열을 반환해야 한다")
     void toLabel_null_returnsEmpty() {
         assertThat(service.toLabel(null)).isEqualTo("");
     }
@@ -211,7 +211,7 @@ class SellerChannelCardQueryServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[예외] sellerId null → BusinessException(INT-001), mapper 미호출")
+    @DisplayName("sellerId가 null이면 채널 카드 목록을 조회했을 때 BusinessException(INT-001)을 발생시키고 mapper를 호출하지 않아야 한다")
     void getChannelCards_throwsWhenSellerIdNull() {
         assertThatThrownBy(() -> service.getChannelCards(null))
                 .isInstanceOf(BusinessException.class);
@@ -219,7 +219,7 @@ class SellerChannelCardQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] sellerId 공백 → BusinessException(INT-001), mapper 미호출")
+    @DisplayName("sellerId가 공백이면 채널 카드 목록을 조회했을 때 BusinessException(INT-001)을 발생시키고 mapper를 호출하지 않아야 한다")
     void getChannelCards_throwsWhenSellerIdBlank() {
         assertThatThrownBy(() -> service.getChannelCards("   "))
                 .isInstanceOf(BusinessException.class);

--- a/src/test/java/com/conk/integration/query/service/SellerChannelDetailQueryServiceTest.java
+++ b/src/test/java/com/conk/integration/query/service/SellerChannelDetailQueryServiceTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("query.SellerChannelDetailQueryService 단위 테스트")
+@DisplayName("SellerChannelDetailQueryService 테스트")
 class SellerChannelDetailQueryServiceTest {
 
     @Mock private ChannelApiQueryService channelApiQueryService;
@@ -30,7 +30,7 @@ class SellerChannelDetailQueryServiceTest {
     @InjectMocks private SellerChannelDetailQueryService service;
 
     @Test
-    @DisplayName("[GREEN] SHOPIFY + ping 성공 → 계약 DTO 반환")
+    @DisplayName("Shopify 자격 증명이 있고 ping에 성공하면 채널 상세를 조회했을 때 계약 DTO를 반환해야 한다")
     void getChannelDetail_shopifyConnected_returnsDetail() {
         ChannelApi channelApi = buildChannelApi("seller-A", "SHOPIFY", "shpat_xxxxxxxx", "my-shopify-store");
         given(channelApiQueryService.findChannelApi("seller-A", "SHOPIFY")).willReturn(channelApi);
@@ -45,7 +45,7 @@ class SellerChannelDetailQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 비-Shopify 채널은 ping 없이 상세 DTO를 반환한다")
+    @DisplayName("Shopify가 아닌 채널이 주어지면 채널 상세를 조회했을 때 ping 없이 상세 DTO를 반환해야 한다")
     void getChannelDetail_nonShopify_returnsDetailWithoutPing() {
         ChannelApi channelApi = buildChannelApi("seller-A", "AMAZON", "amazon-token", "amazon-store");
         given(channelApiQueryService.findChannelApi("seller-A", "AMAZON")).willReturn(channelApi);
@@ -58,7 +58,7 @@ class SellerChannelDetailQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] SHOPIFY ping 실패 → 연결 정보 없음")
+    @DisplayName("Shopify ping에 실패하면 채널 상세를 조회했을 때 연결 정보 없음 예외를 발생시켜야 한다")
     void getChannelDetail_shopifyDisconnected_throwsNotFound() {
         ChannelApi channelApi = buildChannelApi("seller-A", "SHOPIFY", "shpat_xxxxxxxx", "my-shopify-store");
         given(channelApiQueryService.findChannelApi("seller-A", "SHOPIFY")).willReturn(channelApi);
@@ -71,7 +71,7 @@ class SellerChannelDetailQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] sellerId 공백 → INT-001")
+    @DisplayName("sellerId가 공백이면 채널 상세를 조회했을 때 BusinessException(INT-001)을 발생시켜야 한다")
     void getChannelDetail_blankSellerId_throwsInvalidSellerId() {
         assertThatThrownBy(() -> service.getChannelDetail("   ", "SHOPIFY"))
                 .isInstanceOf(BusinessException.class)
@@ -82,7 +82,7 @@ class SellerChannelDetailQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] channelKey 공백 → 연결 정보 없음")
+    @DisplayName("channelKey가 공백이면 채널 상세를 조회했을 때 연결 정보 없음 예외를 발생시켜야 한다")
     void getChannelDetail_blankChannelKey_throwsNotFound() {
         assertThatThrownBy(() -> service.getChannelDetail("seller-A", "   "))
                 .isInstanceOf(BusinessException.class)
@@ -93,7 +93,7 @@ class SellerChannelDetailQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 채널 키는 대문자로 정규화되어 조회된다")
+    @DisplayName("소문자 채널 키가 주어지면 채널 상세를 조회했을 때 대문자로 정규화해 조회해야 한다")
     void getChannelDetail_normalizesChannelKeyToUpperCase() {
         ChannelApi channelApi = buildChannelApi("seller-A", "SHOPIFY", "shpat_xxxxxxxx", "my-shopify-store");
         given(channelApiQueryService.findChannelApi("seller-A", "SHOPIFY")).willReturn(channelApi);
@@ -102,6 +102,43 @@ class SellerChannelDetailQueryServiceTest {
         service.getChannelDetail("seller-A", "shopify");
 
         verify(channelApiQueryService).findChannelApi("seller-A", "SHOPIFY");
+    }
+
+    @Test
+    @DisplayName("audit가 null이면 채널 상세를 조회했을 때 connectedAt을 null로 반환해야 한다")
+    void getChannelDetail_returnsNullConnectedAtWhenAuditIsNull() {
+        ChannelApi channelApi = ChannelApi.builder()
+                .id(new ChannelApiId("seller-A", "AMAZON"))
+                .channelApi("amazon-token")
+                .storeName("amazon-store")
+                .audit(null)
+                .build();
+        given(channelApiQueryService.findChannelApi("seller-A", "AMAZON")).willReturn(channelApi);
+
+        SellerChannelDetailDto result = service.getChannelDetail("seller-A", "AMAZON");
+
+        assertThat(result.getConnectedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("ChannelApiQueryService에서 예외가 발생하면 채널 상세를 조회했을 때 호출자에게 그대로 전파해야 한다")
+    void getChannelDetail_propagatesWhenChannelApiQueryServiceThrows() {
+        given(channelApiQueryService.findChannelApi("seller-A", "SHOPIFY"))
+                .willThrow(new BusinessException(ErrorCode.CHANNEL_CONNECTION_NOT_FOUND));
+
+        assertThatThrownBy(() -> service.getChannelDetail("seller-A", "SHOPIFY"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHANNEL_CONNECTION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("channelKey가 null이면 채널 상세를 조회했을 때 연결 정보 없음 예외를 발생시켜야 한다")
+    void getChannelDetail_nullChannelKey_throwsNotFound() {
+        assertThatThrownBy(() -> service.getChannelDetail("seller-A", null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CHANNEL_CONNECTION_NOT_FOUND);
     }
 
     private ChannelApi buildChannelApi(String sellerId, String channelName, String token, String storeName) {

--- a/src/test/java/com/conk/integration/query/service/SellerChannelOrderQueryServiceTest.java
+++ b/src/test/java/com/conk/integration/query/service/SellerChannelOrderQueryServiceTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 // 주문 조회 서비스의 DTO 변환 규칙과 상태/요약 계산을 검증한다.
 @ExtendWith(MockitoExtension.class)
-@DisplayName("query.SellerChannelOrderQueryService 단위 테스트")
+@DisplayName("SellerChannelOrderQueryService 테스트")
 class SellerChannelOrderQueryServiceTest {
 
     @Mock private SellerChannelOrderMapper channelOrderMapper;
@@ -33,7 +33,7 @@ class SellerChannelOrderQueryServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] mapper raw → DTO 변환 (id, channel, itemsSummary, status 검증)")
+    @DisplayName("주문 조회 결과가 주어지면 주문 목록을 조회했을 때 DTO로 변환해 반환해야 한다")
     void getOrders_mapsRawResultToDto() {
         // 대표 raw 결과 하나로 표시용 필드 변환을 한 번에 확인한다.
         LocalDateTime orderedAt = LocalDateTime.of(2026, 3, 19, 9, 12);
@@ -53,7 +53,7 @@ class SellerChannelOrderQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 빈 결과 → 빈 리스트 반환")
+    @DisplayName("주문 조회 결과가 비어 있으면 주문 목록을 조회했을 때 빈 리스트를 반환해야 한다")
     void getOrders_returnsEmpty_whenMapperReturnsEmpty() {
         given(channelOrderMapper.findBySellerIdWithItemSummary("seller-1")).willReturn(List.of());
 
@@ -61,7 +61,7 @@ class SellerChannelOrderQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] orderAmount 항상 null")
+    @DisplayName("주문 조회 결과가 주어지면 주문 목록을 조회했을 때 orderAmount는 null이어야 한다")
     void getOrders_orderAmountIsAlwaysNull() {
         // 현재 구현은 주문 금액을 채우지 않으므로 null 고정 동작을 드러낸다.
         given(channelOrderMapper.findBySellerIdWithItemSummary("seller-1"))
@@ -71,7 +71,7 @@ class SellerChannelOrderQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[GREEN] conkOrderNo = orderId")
+    @DisplayName("주문 조회 결과가 주어지면 주문 목록을 조회했을 때 conkOrderNo는 orderId와 같아야 한다")
     void getOrders_conkOrderNoEqualsOrderId() {
         given(channelOrderMapper.findBySellerIdWithItemSummary("seller-1"))
                 .willReturn(List.of(buildRaw("ORD-999", "SHOPIFY", "상품A", 1, null, null, LocalDateTime.now())));
@@ -86,31 +86,31 @@ class SellerChannelOrderQueryServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] buildItemsSummary: itemCount=1 → 상품명만 반환")
+    @DisplayName("itemCount가 1이면 상품 요약을 생성했을 때 상품명만 반환해야 한다")
     void buildItemsSummary_singleItem() {
         assertThat(service.buildItemsSummary("루미에르 앰플", 1)).isEqualTo("루미에르 앰플");
     }
 
     @Test
-    @DisplayName("[GREEN] buildItemsSummary: itemCount=2 → '상품명 외 1건'")
+    @DisplayName("itemCount가 2이면 상품 요약을 생성했을 때 상품명 외 1건 형식으로 반환해야 한다")
     void buildItemsSummary_twoItems() {
         assertThat(service.buildItemsSummary("루미에르 앰플", 2)).isEqualTo("루미에르 앰플 외 1건");
     }
 
     @Test
-    @DisplayName("[GREEN] buildItemsSummary: itemCount=3 → '상품명 외 2건'")
+    @DisplayName("itemCount가 3이면 상품 요약을 생성했을 때 상품명 외 2건 형식으로 반환해야 한다")
     void buildItemsSummary_threeItems() {
         assertThat(service.buildItemsSummary("루미에르 앰플", 3)).isEqualTo("루미에르 앰플 외 2건");
     }
 
     @Test
-    @DisplayName("[GREEN] buildItemsSummary: firstItemName null → 빈 문자열")
+    @DisplayName("firstItemName이 null이면 상품 요약을 생성했을 때 빈 문자열을 반환해야 한다")
     void buildItemsSummary_nullFirstName_returnsEmpty() {
         assertThat(service.buildItemsSummary(null, 2)).isEqualTo("");
     }
 
     @Test
-    @DisplayName("[GREEN] buildItemsSummary: firstItemName 공백 → 빈 문자열")
+    @DisplayName("firstItemName이 공백이면 상품 요약을 생성했을 때 빈 문자열을 반환해야 한다")
     void buildItemsSummary_blankFirstName_returnsEmpty() {
         assertThat(service.buildItemsSummary("   ", 2)).isEqualTo("");
     }
@@ -120,25 +120,25 @@ class SellerChannelOrderQueryServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] resolveStatus: invoiceNo null, shippedAt null → NEW")
+    @DisplayName("invoiceNo와 shippedAt이 모두 null이면 주문 상태를 계산했을 때 NEW를 반환해야 한다")
     void resolveStatus_new() {
         assertThat(service.resolveStatus(null, null)).isEqualTo("NEW");
     }
 
     @Test
-    @DisplayName("[GREEN] resolveStatus: invoiceNo 있음, shippedAt null → PROCESSING")
+    @DisplayName("invoiceNo가 있고 shippedAt이 null이면 주문 상태를 계산했을 때 PROCESSING을 반환해야 한다")
     void resolveStatus_processing() {
         assertThat(service.resolveStatus("shp_001", null)).isEqualTo("PROCESSING");
     }
 
     @Test
-    @DisplayName("[GREEN] resolveStatus: shippedAt 있음 → SHIPPED (invoiceNo 무관)")
+    @DisplayName("shippedAt이 있으면 주문 상태를 계산했을 때 invoiceNo와 관계없이 SHIPPED를 반환해야 한다")
     void resolveStatus_shipped() {
         assertThat(service.resolveStatus("shp_001", "2026-03-20")).isEqualTo("SHIPPED");
     }
 
     @Test
-    @DisplayName("[GREEN] resolveStatus: shippedAt 공백 → PROCESSING (공백은 미배송 처리)")
+    @DisplayName("shippedAt이 공백이면 주문 상태를 계산했을 때 PROCESSING을 반환해야 한다")
     void resolveStatus_blankShippedAt_treatedAsNotShipped() {
         assertThat(service.resolveStatus("shp_001", "   ")).isEqualTo("PROCESSING");
     }
@@ -148,7 +148,7 @@ class SellerChannelOrderQueryServiceTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[예외] sellerId null → BusinessException(INT-001), mapper 미호출")
+    @DisplayName("sellerId가 null이면 주문 목록을 조회했을 때 BusinessException(INT-001)을 발생시키고 mapper를 호출하지 않아야 한다")
     void getOrders_throwsWhenSellerIdNull() {
         assertThatThrownBy(() -> service.getOrders(null))
                 .isInstanceOf(BusinessException.class);
@@ -156,7 +156,7 @@ class SellerChannelOrderQueryServiceTest {
     }
 
     @Test
-    @DisplayName("[예외] sellerId 공백 → BusinessException(INT-001), mapper 미호출")
+    @DisplayName("sellerId가 공백이면 주문 목록을 조회했을 때 BusinessException(INT-001)을 발생시키고 mapper를 호출하지 않아야 한다")
     void getOrders_throwsWhenSellerIdBlank() {
         assertThatThrownBy(() -> service.getOrders("  "))
                 .isInstanceOf(BusinessException.class);

--- a/src/test/java/com/conk/integration/query/service/ShopifyPingClientTest.java
+++ b/src/test/java/com/conk/integration/query/service/ShopifyPingClientTest.java
@@ -20,7 +20,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 // Shopify ping 클라이언트의 요청 형식, 응답 해석, 예외 무전파를 검증한다.
-@DisplayName("ShopifyPingClient 단위 테스트")
+@DisplayName("ShopifyPingClient 테스트")
 class ShopifyPingClientTest {
 
     private MockRestServiceServer mockServer;
@@ -46,7 +46,7 @@ class ShopifyPingClientTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] GraphQL 엔드포인트로 POST 요청을 전송한다")
+    @DisplayName("스토어 이름과 액세스 토큰이 주어지면 연결 확인을 수행했을 때 GraphQL 엔드포인트로 POST 요청을 전송해야 한다")
     void ping_postsToGraphQLUrl() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andExpect(method(HttpMethod.POST))
@@ -58,7 +58,7 @@ class ShopifyPingClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] X-Shopify-Access-Token 헤더를 포함한다")
+    @DisplayName("스토어 이름과 액세스 토큰이 주어지면 연결 확인을 수행했을 때 X-Shopify-Access-Token 헤더를 포함해야 한다")
     void ping_includesAccessTokenHeader() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andExpect(header("X-Shopify-Access-Token", ACCESS_TOKEN))
@@ -73,7 +73,7 @@ class ShopifyPingClientTest {
     // ─────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("[GREEN] 200 응답 → true 반환")
+    @DisplayName("200 응답이 주어지면 연결 확인을 수행했을 때 true를 반환해야 한다")
     void ping_returns_true_on200() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withSuccess("{\"data\":{\"shop\":{\"id\":\"gid://shopify/Shop/1\"}}}", MediaType.APPLICATION_JSON));
@@ -82,7 +82,7 @@ class ShopifyPingClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 401 Unauthorized → false 반환 (예외 전파 없음)")
+    @DisplayName("401 응답이 주어지면 연결 확인을 수행했을 때 예외를 전파하지 않고 false를 반환해야 한다")
     void ping_returns_false_on401() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
@@ -91,7 +91,7 @@ class ShopifyPingClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 403 Forbidden → false 반환 (예외 전파 없음)")
+    @DisplayName("403 응답이 주어지면 연결 확인을 수행했을 때 예외를 전파하지 않고 false를 반환해야 한다")
     void ping_returns_false_on403() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withStatus(HttpStatus.FORBIDDEN));
@@ -100,7 +100,7 @@ class ShopifyPingClientTest {
     }
 
     @Test
-    @DisplayName("[GREEN] 500 서버 오류 → false 반환 (예외 전파 없음)")
+    @DisplayName("500 응답이 주어지면 연결 확인을 수행했을 때 예외를 전파하지 않고 false를 반환해야 한다")
     void ping_returns_false_on500() {
         mockServer.expect(requestTo(graphqlUrl()))
                 .andRespond(withServerError());

--- a/src/test/java/com/conk/integration/query/service/ShopifyPingClientTest.java
+++ b/src/test/java/com/conk/integration/query/service/ShopifyPingClientTest.java
@@ -108,6 +108,12 @@ class ShopifyPingClientTest {
         assertThat(client.ping(STORE_NAME, ACCESS_TOKEN)).isFalse();
     }
 
+    @Test
+    @DisplayName("유효하지 않은 storeName이 주어지면 연결 확인을 수행했을 때 예외를 전파하지 않고 false를 반환해야 한다")
+    void ping_returnsFalse_whenStoreNameIsInvalid() {
+        assertThat(client.ping("https://evil.example", ACCESS_TOKEN)).isFalse();
+    }
+
     // ─────────────────────────────────────────────────────────
     // Helper
     // ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## 📝 작업 내용
- 셀러 채널 연결 API `POST /integrations/seller/channels/{channelKey}/connect`를 추가했습니다.
- Shopify ping 검증 후 `channel_api` 연결 정보를 저장하거나 갱신하도록 구현했습니다.
- 채널 기준 주문 동기화 API `POST /integrations/seller/channels/{channelKey}/sync`를 추가했습니다.
- `import-orders`와 channelKey 기반 sync 흐름을 공통 메서드로 정리했습니다.
- `ChannelApi`, `ChannelOrderItem`의 update/audit lifecycle 동작을 보강했습니다.
- 관련 controller/service/query/common 테스트를 보강했습니다.

## 📂 관련 파일 (Scope)
- src/main/java/com/conk/integration/command/application/controller/IntegrationCommandController.java
- src/main/java/com/conk/integration/command/application/dto/request/SellerChannelConnectRequest.java
- src/main/java/com/conk/integration/command/application/service/SellerChannelConnectService.java
- src/main/java/com/conk/integration/command/domain/aggregate/ChannelApi.java
- src/main/java/com/conk/integration/command/domain/aggregate/ChannelOrderItem.java
- src/test/java/com/conk/integration/command/application/controller/IntegrationCommandControllerTest.java
- src/test/java/com/conk/integration/command/application/service/SellerChannelConnectServiceTest.java
- src/test/java/com/conk/integration/query/service/ChannelApiQueryServiceTest.java
- src/test/java/com/conk/integration/query/service/SellerChannelDetailQueryServiceTest.java

## 🎯 관련 이슈
- Close #33

## ⚠️ 유의사항 및 특이사항
- 현재 채널 연결 및 channelKey 기반 sync는 `SHOPIFY`만 지원합니다.
- `SellerChannelConnectRequest`의 `storeAlias`, `contactEmail`, `syncMode`는 현재 저장 로직에서 사용하지 않습니다.
- 요청 필수값 검증 일부는 기존 `ErrorCode.INVALID_SELLER_ID`를 재사용합니다.

## 🔄 로직 시각화

### 1. 셀러 채널 연결 호출 흐름
```mermaid
sequenceDiagram
    participant Client as Client
    participant Controller as IntegrationCommandController.connectSellerChannel
    participant Service as SellerChannelConnectService.connect
    participant Ping as ShopifyPingClient.ping
    participant Repo as ChannelApiRepository
    participant Entity as ChannelApi

    Client->>Controller: POST /integrations/seller/channels/{channelKey}/connect
    Controller->>Service: connect(sellerId, channelKey, request)
    Note over Service: validateSellerId(sellerId)<br/>normalizeChannelKey(channelKey)<br/>validateRequest(request)<br/>ensureSupportedChannel(normalizedChannelKey)
    Service->>Ping: ping(storeName.trim(), channelApi.trim())
    Ping-->>Service: true / false

    alt ping 실패
        Service-->>Controller: BusinessException(CHANNEL_CONNECTION_NOT_FOUND, INT-404)
        Controller-->>Client: error response (INT-404)
    else ping 성공
        Service->>Repo: findById(new ChannelApiId(sellerId, normalizedChannelKey))
        Repo-->>Service: Optional<ChannelApi>

        alt 기존 연결 존재
            Service->>Entity: updateConnection(channelApi, storeName)
        else 신규 연결
            Service->>Entity: ChannelApi.builder(...)
        end

        Service->>Repo: saveAndFlush(channelApi)
        Repo-->>Service: saved ChannelApi
        Service-->>Controller: SellerChannelDetailDto
        Controller-->>Client: ApiResponse.ok(response)
    end
```

### 2. 채널별 주문 동기화 호출 흐름
```mermaid
sequenceDiagram
    participant Client as Client
    participant Controller as IntegrationCommandController.syncChannelOrdersByChannel
    participant Shared as IntegrationCommandController.syncChannelOrdersByChannelKey
    participant Dispatch as ChannelOrderSyncDispatchService.sync
    participant Syncer as selected ChannelOrderSyncer

    Client->>Controller: POST /integrations/seller/channels/{channelKey}/sync
    Controller->>Shared: syncChannelOrdersByChannelKey(sellerId, channelKey)
    Note over Shared: toOrderChannel(channelKey)

    alt 지원하지 않는 channelKey
        Shared-->>Controller: BusinessException(UNSUPPORTED_CHANNEL, INT-004)
        Controller-->>Client: error response (INT-004)
    else 지원 채널
        Shared->>Dispatch: sync(sellerId, orderChannel)
        Note over Dispatch: syncer.supports(orderChannel) 탐색

        alt 지원 syncer 없음
            Dispatch-->>Shared: BusinessException(UNSUPPORTED_CHANNEL, INT-004)
            Shared-->>Controller: exception
            Controller-->>Client: error response (INT-004)
        else 지원 syncer 존재
            Dispatch->>Syncer: syncOrders(sellerId)
            Syncer-->>Dispatch: ChannelOrderSyncResponse
            Dispatch-->>Shared: ChannelOrderSyncResponse
            Shared-->>Controller: ChannelOrderSyncResponse
            Controller-->>Client: ApiResponse.ok(response)
        end
    end
```

### 3. import-orders 공통화 호출 흐름
```mermaid
sequenceDiagram
    participant Client as Client
    participant Controller as IntegrationCommandController.importChannelOrders
    participant Shared as IntegrationCommandController.syncChannelOrdersByChannelKey
    participant Dispatch as ChannelOrderSyncDispatchService.sync
    participant Mapper as ChannelOrderImportResponse

    Client->>Controller: POST /integrations/seller/channels/{channelKey}/import-orders
    Controller->>Shared: syncChannelOrdersByChannelKey(sellerId, channelKey)
    Note over Shared: 내부에서 toOrderChannel(channelKey) 수행<br/>지원하지 않는 채널이면 INT-004 예외 반환
    Shared->>Dispatch: sync(sellerId, orderChannel)
    Dispatch-->>Shared: ChannelOrderSyncResponse
    Shared-->>Controller: ChannelOrderSyncResponse
    Controller->>Mapper: from(response)
    Mapper-->>Controller: ChannelOrderImportResponse
    Controller-->>Client: ApiResponse.ok(importResponse)
```

## ✅ 체크리스트
- [x] 커밋 내역이 정리되어 있는가?
- [x] 불필요한 파일이 없는가?
