### PR TITLE
feat: Shopify import-preview API 추가 및 preview count 페이지네이션 적용

### DIFF
--- a/src/main/java/com/conk/integration/command/application/controller/IntegrationCommandController.java
+++ b/src/main/java/com/conk/integration/command/application/controller/IntegrationCommandController.java
@@ -6,9 +6,11 @@ import com.conk.integration.command.application.dto.request.ChannelOrderSyncRequ
 import com.conk.integration.command.application.dto.request.EasyPostCreateShipmentRequest;
 import com.conk.integration.command.application.dto.request.ManualOrderInvoiceRequest;
 import com.conk.integration.command.application.dto.request.SellerChannelConnectRequest;
+import com.conk.integration.command.application.dto.request.SellerChannelImportPreviewRequest;
 import com.conk.integration.command.application.dto.response.BulkFulfillmentResponse;
 import com.conk.integration.command.application.dto.response.BulkInvoiceResponse;
 import com.conk.integration.command.application.dto.response.ChannelOrderImportResponse;
+import com.conk.integration.command.application.dto.response.SellerChannelImportPreviewResponse;
 import com.conk.integration.command.application.dto.response.ChannelOrderSyncResponse;
 import com.conk.integration.command.application.dto.response.EasyPostInvoiceResponse;
 import com.conk.integration.command.application.dto.response.ManualOrderInvoiceResponse;
@@ -17,6 +19,7 @@ import com.conk.integration.command.application.service.ChannelOrderSyncDispatch
 import com.conk.integration.command.application.service.EasyPostInvoiceSaveService;
 import com.conk.integration.command.application.service.ManualOrderInvoiceService;
 import com.conk.integration.command.application.service.SellerChannelConnectService;
+import com.conk.integration.command.application.service.SellerChannelImportPreviewService;
 import com.conk.integration.command.domain.aggregate.EasypostShipmentInvoice;
 import com.conk.integration.command.domain.aggregate.enums.OrderChannel;
 import com.conk.integration.common.ApiResponse;
@@ -43,6 +46,7 @@ public class IntegrationCommandController {
     private final ChannelOrderSyncDispatchService orderSyncDispatchService;
     private final ManualOrderInvoiceService manualOrderInvoiceService;
     private final SellerChannelConnectService sellerChannelConnectService;
+    private final SellerChannelImportPreviewService sellerChannelImportPreviewService;
 
     /**
      * 셀러 채널 연결
@@ -96,6 +100,21 @@ public class IntegrationCommandController {
 
         ChannelOrderSyncResponse response = syncChannelOrdersByChannelKey(sellerId, channelKey);
         return ResponseEntity.ok(ApiResponse.ok(ChannelOrderImportResponse.from(response)));
+    }
+
+    /**
+     * 채널 주문 가져오기 미리보기
+     * POST /integrations/seller/channels/{channelKey}/import-preview
+     */
+    @PostMapping("/seller/channels/{channelKey}/import-preview")
+    public ResponseEntity<ApiResponse<SellerChannelImportPreviewResponse>> importChannelPreview(
+            @RequestHeader("X-Seller-Id") String sellerId,
+            @PathVariable String channelKey,
+            @RequestBody(required = false) SellerChannelImportPreviewRequest request) {
+
+        SellerChannelImportPreviewResponse response = sellerChannelImportPreviewService.preview(
+                sellerId, toOrderChannel(channelKey), request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     /**

--- a/src/main/java/com/conk/integration/command/application/dto/request/SellerChannelImportPreviewRequest.java
+++ b/src/main/java/com/conk/integration/command/application/dto/request/SellerChannelImportPreviewRequest.java
@@ -1,0 +1,17 @@
+package com.conk.integration.command.application.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 셀러 채널 주문 가져오기 미리보기 요청 body를 표현한다.
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SellerChannelImportPreviewRequest {
+
+    private String storeAlias;
+    private String contactEmail;
+    private String syncWindow;
+    private Boolean autoImport;
+}

--- a/src/main/java/com/conk/integration/command/application/dto/response/SellerChannelImportPreviewResponse.java
+++ b/src/main/java/com/conk/integration/command/application/dto/response/SellerChannelImportPreviewResponse.java
@@ -1,0 +1,15 @@
+package com.conk.integration.command.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+// 셀러 채널 주문 가져오기 미리보기 결과를 반환하는 응답 DTO다.
+@Getter
+@AllArgsConstructor
+public class SellerChannelImportPreviewResponse {
+
+    private int pendingOrders;
+    private LocalDateTime lastSyncedAt;
+}

--- a/src/main/java/com/conk/integration/command/application/dto/response/ShopifyOrderResponse.java
+++ b/src/main/java/com/conk/integration/command/application/dto/response/ShopifyOrderResponse.java
@@ -32,6 +32,21 @@ public class ShopifyOrderResponse {
 
         @JsonProperty("edges")
         private List<OrderEdge> edges;
+
+        @JsonProperty("pageInfo")
+        private PageInfo pageInfo;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class PageInfo {
+
+        @JsonProperty("hasNextPage")
+        private boolean hasNextPage;
+
+        @JsonProperty("endCursor")
+        private String endCursor;
     }
 
     @Getter

--- a/src/main/java/com/conk/integration/command/application/service/SellerChannelImportPreviewService.java
+++ b/src/main/java/com/conk/integration/command/application/service/SellerChannelImportPreviewService.java
@@ -1,0 +1,91 @@
+package com.conk.integration.command.application.service;
+
+import com.conk.integration.command.application.dto.request.SellerChannelImportPreviewRequest;
+import com.conk.integration.command.application.dto.response.SellerChannelImportPreviewResponse;
+import com.conk.integration.command.domain.aggregate.enums.OrderChannel;
+import com.conk.integration.command.infrastructure.repository.ChannelOrderRepository;
+import com.conk.integration.command.infrastructure.service.ShopifyOrderClient;
+import com.conk.integration.common.exception.BusinessException;
+import com.conk.integration.common.exception.ErrorCode;
+import com.conk.integration.query.dto.ShopifyCredentialDto;
+import com.conk.integration.query.service.ChannelApiQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+// 셀러 채널 주문 가져오기 미리보기를 수행하는 read-only command 서비스다.
+@Service
+@RequiredArgsConstructor
+public class SellerChannelImportPreviewService {
+
+    private final ChannelApiQueryService channelApiQueryService;
+    private final ChannelOrderRepository channelOrderRepository;
+    private final ShopifyOrderClient shopifyOrderClient;
+
+    public SellerChannelImportPreviewResponse preview(
+            String sellerId,
+            OrderChannel orderChannel,
+            SellerChannelImportPreviewRequest request) {
+
+        validateSellerId(sellerId);
+        ensureSupportedChannel(orderChannel);
+
+        ShopifyCredentialDto credential = channelApiQueryService.findShopifyCredential(sellerId);
+        LocalDateTime lastSyncedAt = findLatestCreatedAt(sellerId, orderChannel);
+        LocalDateTime since = resolveSince(lastSyncedAt, request);
+
+        int pendingOrders = shopifyOrderClient.countOrdersSince(
+                credential.getStoreName(),
+                credential.getAccessToken(),
+                since);
+
+        return new SellerChannelImportPreviewResponse(pendingOrders, lastSyncedAt);
+    }
+
+    private void validateSellerId(String sellerId) {
+        if (sellerId == null || sellerId.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_SELLER_ID);
+        }
+    }
+
+    private void ensureSupportedChannel(OrderChannel orderChannel) {
+        if (orderChannel != OrderChannel.SHOPIFY) {
+            throw new BusinessException(
+                    ErrorCode.UNSUPPORTED_CHANNEL,
+                    "지원하지 않는 주문 동기화 채널입니다: " + orderChannel);
+        }
+    }
+
+    private LocalDateTime findLatestCreatedAt(String sellerId, OrderChannel orderChannel) {
+        return channelOrderRepository.findFirstBySellerIdAndOrderChannelOrderByAuditCreatedAtDesc(
+                        sellerId,
+                        orderChannel)
+                .map(order -> order.getAudit())
+                .filter(audit -> audit != null && audit.getCreatedAt() != null)
+                .map(audit -> audit.getCreatedAt())
+                .orElse(null);
+    }
+
+    private LocalDateTime resolveSince(LocalDateTime lastSyncedAt, SellerChannelImportPreviewRequest request) {
+        if (lastSyncedAt != null) {
+            return lastSyncedAt;
+        }
+
+        return LocalDateTime.now().minus(parseSyncWindow(request));
+    }
+
+    private Duration parseSyncWindow(SellerChannelImportPreviewRequest request) {
+        String syncWindow = request != null ? request.getSyncWindow() : null;
+        String normalized = syncWindow == null ? "" : syncWindow.trim();
+
+        return switch (normalized) {
+            case "최근 1일" -> Duration.ofDays(1);
+            case "최근 3일" -> Duration.ofDays(3);
+            case "최근 14일" -> Duration.ofDays(14);
+            case "최근 7일" -> Duration.ofDays(7);
+            default -> Duration.ofDays(7);
+        };
+    }
+}

--- a/src/main/java/com/conk/integration/command/infrastructure/repository/ChannelOrderRepository.java
+++ b/src/main/java/com/conk/integration/command/infrastructure/repository/ChannelOrderRepository.java
@@ -1,13 +1,20 @@
 package com.conk.integration.command.infrastructure.repository;
 
 import com.conk.integration.command.domain.aggregate.ChannelOrder;
+import com.conk.integration.command.domain.aggregate.enums.OrderChannel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 // 표준화된 채널 주문 aggregate를 저장/조회한다.
 public interface ChannelOrderRepository extends JpaRepository<ChannelOrder, String> {
 
     // 셀러별 주문 목록 조회에 사용된다.
     List<ChannelOrder> findBySellerId(String sellerId);
+
+    // 셀러/채널 기준 가장 최근에 저장된 주문 1건을 조회한다.
+    Optional<ChannelOrder> findFirstBySellerIdAndOrderChannelOrderByAuditCreatedAtDesc(
+            String sellerId,
+            OrderChannel orderChannel);
 }

--- a/src/main/java/com/conk/integration/command/infrastructure/service/ShopifyOrderClient.java
+++ b/src/main/java/com/conk/integration/command/infrastructure/service/ShopifyOrderClient.java
@@ -14,6 +14,9 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -22,9 +25,9 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ShopifyOrderClient {
 
-    private static final String ORDERS_QUERY = """
+    private static final String ORDERS_QUERY_TEMPLATE = """
             {
-              orders(first: 250) {
+              orders(first: 250%s%s) {
                 edges {
                   node {
                     id
@@ -64,6 +67,10 @@ public class ShopifyOrderClient {
                     }
                   }
                 }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
               }
             }
             """;
@@ -80,8 +87,52 @@ public class ShopifyOrderClient {
      * @return 주문 노드 목록
      */
     public List<ShopifyOrderResponse.OrderNode> getOrders(String storeName, String accessToken) {
+        return toOrderNodes(fetchOrders(storeName, accessToken, null, null));
+    }
+
+    /**
+     * Shopify GraphQL로 특정 시각 이후 주문 목록과 fulfillmentOrder ID를 한 번에 조회한다.
+     *
+     * @param storeName   Shopify 스토어명
+     * @param accessToken Shopify Admin API 액세스 토큰
+     * @param since       조회 시작 시각(초과 조건)
+     * @return 주문 노드 목록
+     */
+    public List<ShopifyOrderResponse.OrderNode> getOrdersSince(
+            String storeName,
+            String accessToken,
+            LocalDateTime since) {
+
+        return toOrderNodes(fetchOrders(storeName, accessToken, since, null));
+    }
+
+    public int countOrdersSince(String storeName, String accessToken, LocalDateTime since) {
+        String cursor = null;
+        int total = 0;
+
+        do {
+            ShopifyOrderResponse response = fetchOrders(storeName, accessToken, since, cursor);
+            List<ShopifyOrderResponse.OrderEdge> edges = getOrderEdges(response);
+            total += edges.size();
+
+            ShopifyOrderResponse.PageInfo pageInfo = response.getData().getOrders().getPageInfo();
+            if (pageInfo == null || !pageInfo.isHasNextPage()) {
+                break;
+            }
+            cursor = pageInfo.getEndCursor();
+        } while (cursor != null && !cursor.isBlank());
+
+        return total;
+    }
+
+    private ShopifyOrderResponse fetchOrders(
+            String storeName,
+            String accessToken,
+            LocalDateTime since,
+            String cursor) {
+
         try {
-            String jsonBody = objectMapper.writeValueAsString(Map.of("query", ORDERS_QUERY));
+            String jsonBody = objectMapper.writeValueAsString(Map.of("query", buildOrdersQuery(since, cursor)));
             HttpEntity<String> entity = new HttpEntity<>(jsonBody, buildHeaders(accessToken));
 
             ShopifyOrderResponse response = restTemplate.exchange(
@@ -95,14 +146,32 @@ public class ShopifyOrderClient {
                     || response.getData().getOrders() == null) {
                 throw new BusinessException(ErrorCode.SHOPIFY_EMPTY_RESPONSE);
             }
-
-            return response.getData().getOrders().getEdges().stream()
-                    .map(ShopifyOrderResponse.OrderEdge::getNode)
-                    .toList();
+            return response;
 
         } catch (JsonProcessingException e) {
             throw new BusinessException(ErrorCode.SHOPIFY_SERIALIZATION_FAILED);
         }
+    }
+
+    private List<ShopifyOrderResponse.OrderNode> toOrderNodes(ShopifyOrderResponse response) {
+        return getOrderEdges(response).stream()
+                .map(ShopifyOrderResponse.OrderEdge::getNode)
+                .toList();
+    }
+
+    private List<ShopifyOrderResponse.OrderEdge> getOrderEdges(ShopifyOrderResponse response) {
+        List<ShopifyOrderResponse.OrderEdge> edges = response.getData().getOrders().getEdges();
+        return edges == null ? Collections.emptyList() : edges;
+    }
+
+    private String buildOrdersQuery(LocalDateTime since, String cursor) {
+        String filterClause = since == null ? "" : ", query: \"" + buildCreatedAtFilter(since) + "\"";
+        String cursorClause = (cursor == null || cursor.isBlank()) ? "" : ", after: \"" + cursor + "\"";
+        return ORDERS_QUERY_TEMPLATE.formatted(filterClause, cursorClause);
+    }
+
+    private String buildCreatedAtFilter(LocalDateTime since) {
+        return "created_at:>'" + since.atOffset(ZoneOffset.UTC) + "'";
     }
 
     // 토큰과 JSON content-type을 포함한 Shopify 요청 헤더다.

--- a/src/test/java/com/conk/integration/command/application/controller/IntegrationCommandControllerTest.java
+++ b/src/test/java/com/conk/integration/command/application/controller/IntegrationCommandControllerTest.java
@@ -7,10 +7,12 @@ import com.conk.integration.command.application.dto.response.BulkFulfillmentResp
 import com.conk.integration.command.application.dto.response.BulkInvoiceResponse;
 import com.conk.integration.command.application.dto.response.ChannelOrderSyncResponse;
 import com.conk.integration.command.application.dto.response.ManualOrderInvoiceResponse;
+import com.conk.integration.command.application.dto.response.SellerChannelImportPreviewResponse;
 import com.conk.integration.command.application.service.ChannelFulfillmentDispatchService;
 import com.conk.integration.command.application.service.ChannelOrderSyncDispatchService;
 import com.conk.integration.command.application.service.EasyPostInvoiceSaveService;
 import com.conk.integration.command.application.service.ManualOrderInvoiceService;
+import com.conk.integration.command.application.service.SellerChannelImportPreviewService;
 import com.conk.integration.command.domain.aggregate.EasypostShipmentInvoice;
 import com.conk.integration.command.domain.aggregate.enums.CarrierType;
 import com.conk.integration.common.exception.BusinessException;
@@ -61,6 +63,9 @@ class IntegrationCommandControllerTest {
 
     @MockitoBean
     private SellerChannelConnectService sellerChannelConnectService;
+
+    @MockitoBean
+    private SellerChannelImportPreviewService sellerChannelImportPreviewService;
 
     @Nested
     @DisplayName("셀러 채널 연결 테스트")
@@ -572,6 +577,84 @@ class IntegrationCommandControllerTest {
         @DisplayName("GET 메서드로 채널 주문 가져오기를 요청했을 때 HTTP 405 응답을 반환해야 한다")
         void importChannelOrders_wrongMethod_returns405() throws Exception {
             mockMvc.perform(get("/integrations/seller/channels/{channelKey}/import-orders", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-001"))
+                    .andExpect(status().isMethodNotAllowed());
+        }
+    }
+
+    @Nested
+    @DisplayName("채널 주문 가져오기 미리보기 테스트")
+    class ImportChannelPreviewTests {
+
+        private static final String REQUEST_BODY = """
+                {
+                  "storeAlias": "Shopify KR Store",
+                  "contactEmail": "ops@example.com",
+                  "syncWindow": "최근 7일",
+                  "autoImport": true
+                }
+                """;
+
+        @Test
+        @DisplayName("유효한 판매자 헤더와 요청 본문이 주어지면 채널 주문 가져오기 미리보기를 요청했을 때 HTTP 200 응답과 미리보기 정보를 반환해야 한다")
+        void importChannelPreview_returns200() throws Exception {
+            SellerChannelImportPreviewResponse response = new SellerChannelImportPreviewResponse(
+                    5,
+                    java.time.LocalDateTime.of(2026, 4, 11, 9, 0));
+            given(sellerChannelImportPreviewService.preview(anyString(), any(), any())).willReturn(response);
+
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/import-preview", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-001")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(REQUEST_BODY))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.pendingOrders").value(5))
+                    .andExpect(jsonPath("$.data.lastSyncedAt").value("2026-04-11T09:00:00"));
+        }
+
+        @Test
+        @DisplayName("요청 본문이 없는 요청이 주어지면 채널 주문 가져오기 미리보기를 요청했을 때 HTTP 200 응답과 미리보기 정보를 반환해야 한다")
+        void importChannelPreview_withoutBody_returns200() throws Exception {
+            SellerChannelImportPreviewResponse response = new SellerChannelImportPreviewResponse(0, null);
+            given(sellerChannelImportPreviewService.preview(anyString(), any(), any())).willReturn(response);
+
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/import-preview", "SHOPIFY")
+                            .header("X-Seller-Id", "seller-001"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data.pendingOrders").value(0))
+                    .andExpect(jsonPath("$.data.lastSyncedAt").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("판매자 헤더가 없는 요청이 주어지면 채널 주문 가져오기 미리보기를 요청했을 때 HTTP 400 응답을 반환해야 한다")
+        void importChannelPreview_missingSellerIdHeader_returns400() throws Exception {
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/import-preview", "SHOPIFY")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(REQUEST_BODY))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.message").value("필수 헤더가 누락되었습니다: X-Seller-Id"));
+        }
+
+        @Test
+        @DisplayName("지원하지 않는 채널 키가 주어지면 채널 주문 가져오기 미리보기를 요청했을 때 HTTP 400 응답을 반환해야 한다")
+        void importChannelPreview_unsupportedChannel_returns400() throws Exception {
+            mockMvc.perform(post("/integrations/seller/channels/{channelKey}/import-preview", "UNKNOWN")
+                            .header("X-Seller-Id", "seller-001")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(REQUEST_BODY))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.success").value(false))
+                    .andExpect(jsonPath("$.code").value("INT-004"))
+                    .andExpect(jsonPath("$.message").value("지원하지 않는 주문 동기화 채널입니다: UNKNOWN"));
+        }
+
+        @Test
+        @DisplayName("GET 메서드로 채널 주문 가져오기 미리보기를 요청했을 때 HTTP 405 응답을 반환해야 한다")
+        void importChannelPreview_wrongMethod_returns405() throws Exception {
+            mockMvc.perform(get("/integrations/seller/channels/{channelKey}/import-preview", "SHOPIFY")
                             .header("X-Seller-Id", "seller-001"))
                     .andExpect(status().isMethodNotAllowed());
         }

--- a/src/test/java/com/conk/integration/command/application/service/SellerChannelImportPreviewServiceTest.java
+++ b/src/test/java/com/conk/integration/command/application/service/SellerChannelImportPreviewServiceTest.java
@@ -1,0 +1,153 @@
+package com.conk.integration.command.application.service;
+
+import com.conk.integration.command.application.dto.request.SellerChannelImportPreviewRequest;
+import com.conk.integration.command.application.dto.response.SellerChannelImportPreviewResponse;
+import com.conk.integration.command.domain.aggregate.ChannelOrder;
+import com.conk.integration.command.domain.aggregate.embeddable.AuditFields;
+import com.conk.integration.command.domain.aggregate.enums.OrderChannel;
+import com.conk.integration.command.infrastructure.repository.ChannelOrderRepository;
+import com.conk.integration.command.infrastructure.service.ShopifyOrderClient;
+import com.conk.integration.common.exception.BusinessException;
+import com.conk.integration.query.dto.ShopifyCredentialDto;
+import com.conk.integration.query.service.ChannelApiQueryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SellerChannelImportPreviewService 테스트")
+class SellerChannelImportPreviewServiceTest {
+
+    private static final String SELLER_ID = "seller-001";
+
+    @Mock
+    private ChannelApiQueryService channelApiQueryService;
+
+    @Mock
+    private ChannelOrderRepository channelOrderRepository;
+
+    @Mock
+    private ShopifyOrderClient shopifyOrderClient;
+
+    @InjectMocks
+    private SellerChannelImportPreviewService service;
+
+    @Test
+    @DisplayName("최근 저장 시각이 있으면 미리보기를 수행했을 때 해당 createdAt 이후로 Shopify 주문을 조회해야 한다")
+    void preview_usesLatestCreatedAtAsSince() {
+        LocalDateTime lastCreatedAt = LocalDateTime.of(2026, 4, 11, 9, 0);
+        SellerChannelImportPreviewRequest request = new SellerChannelImportPreviewRequest(
+                "Shopify KR Store",
+                "ops@example.com",
+                "최근 7일",
+                true);
+        given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
+        given(channelOrderRepository.findFirstBySellerIdAndOrderChannelOrderByAuditCreatedAtDesc(
+                SELLER_ID, OrderChannel.SHOPIFY)).willReturn(Optional.of(buildChannelOrder(lastCreatedAt)));
+        given(shopifyOrderClient.countOrdersSince(anyString(), anyString(), any())).willReturn(2);
+
+        SellerChannelImportPreviewResponse response = service.preview(SELLER_ID, OrderChannel.SHOPIFY, request);
+
+        ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+        then(shopifyOrderClient).should().countOrdersSince(anyString(), anyString(), captor.capture());
+        assertThat(captor.getValue()).isEqualTo(lastCreatedAt);
+        assertThat(response.getPendingOrders()).isEqualTo(2);
+        assertThat(response.getLastSyncedAt()).isEqualTo(lastCreatedAt);
+        then(channelOrderRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("최근 저장 시각이 없으면 미리보기를 수행했을 때 현재 시각에서 syncWindow를 뺀 시각 이후로 Shopify 주문을 조회해야 한다")
+    void preview_usesNowMinusSyncWindowWhenLastCreatedAtMissing() {
+        LocalDateTime before = LocalDateTime.now();
+        SellerChannelImportPreviewRequest request = new SellerChannelImportPreviewRequest(
+                null,
+                null,
+                "최근 3일",
+                true);
+        given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
+        given(channelOrderRepository.findFirstBySellerIdAndOrderChannelOrderByAuditCreatedAtDesc(
+                SELLER_ID, OrderChannel.SHOPIFY)).willReturn(Optional.empty());
+        given(shopifyOrderClient.countOrdersSince(anyString(), anyString(), any())).willReturn(0);
+
+        SellerChannelImportPreviewResponse response = service.preview(SELLER_ID, OrderChannel.SHOPIFY, request);
+
+        LocalDateTime after = LocalDateTime.now();
+        ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+        then(shopifyOrderClient).should().countOrdersSince(anyString(), anyString(), captor.capture());
+        assertThat(captor.getValue()).isAfterOrEqualTo(before.minusDays(3));
+        assertThat(captor.getValue()).isBeforeOrEqualTo(after.minusDays(3));
+        assertThat(response.getPendingOrders()).isZero();
+        assertThat(response.getLastSyncedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 syncWindow가 주어지면 미리보기를 수행했을 때 기본 7일 범위를 사용해야 한다")
+    void preview_usesDefaultSevenDaysWhenSyncWindowUnknown() {
+        LocalDateTime before = LocalDateTime.now();
+        SellerChannelImportPreviewRequest request = new SellerChannelImportPreviewRequest(
+                null,
+                null,
+                "최근 30일",
+                false);
+        given(channelApiQueryService.findShopifyCredential(SELLER_ID)).willReturn(buildCredential());
+        given(channelOrderRepository.findFirstBySellerIdAndOrderChannelOrderByAuditCreatedAtDesc(
+                SELLER_ID, OrderChannel.SHOPIFY)).willReturn(Optional.empty());
+        given(shopifyOrderClient.countOrdersSince(anyString(), anyString(), any())).willReturn(0);
+
+        service.preview(SELLER_ID, OrderChannel.SHOPIFY, request);
+
+        LocalDateTime after = LocalDateTime.now();
+        ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+        then(shopifyOrderClient).should().countOrdersSince(anyString(), anyString(), captor.capture());
+        assertThat(captor.getValue()).isAfterOrEqualTo(before.minusDays(7));
+        assertThat(captor.getValue()).isBeforeOrEqualTo(after.minusDays(7));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 채널이 주어지면 미리보기를 수행했을 때 BusinessException을 발생시켜야 한다")
+    void preview_throwsWhenChannelUnsupported() {
+        assertThatThrownBy(() -> service.preview(SELLER_ID, OrderChannel.AMAZON, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("지원하지 않는 주문 동기화 채널입니다: AMAZON");
+    }
+
+    @Test
+    @DisplayName("sellerId가 비어 있으면 미리보기를 수행했을 때 BusinessException을 발생시켜야 한다")
+    void preview_throwsWhenSellerIdBlank() {
+        assertThatThrownBy(() -> service.preview(" ", OrderChannel.SHOPIFY, null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    private ShopifyCredentialDto buildCredential() {
+        ShopifyCredentialDto dto = new ShopifyCredentialDto();
+        dto.setStoreName("conktest");
+        dto.setAccessToken("test-token");
+        return dto;
+    }
+
+    private ChannelOrder buildChannelOrder(LocalDateTime createdAt) {
+        return ChannelOrder.builder()
+                .orderId("1001")
+                .channelOrderNo("#1001")
+                .orderChannel(OrderChannel.SHOPIFY)
+                .sellerId(SELLER_ID)
+                .audit(AuditFields.builder().createdAt(createdAt).updatedAt(createdAt).build())
+                .build();
+    }
+}

--- a/src/test/java/com/conk/integration/command/infrastructure/service/ShopifyOrderClientTest.java
+++ b/src/test/java/com/conk/integration/command/infrastructure/service/ShopifyOrderClientTest.java
@@ -14,10 +14,12 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
 
@@ -109,6 +111,41 @@ class ShopifyOrderClientTest {
         List<ShopifyOrderResponse.OrderNode> orders = client.getOrders(STORE_NAME, ACCESS_TOKEN);
 
         assertThat(orders).isEmpty();
+    }
+
+    @Test
+    @DisplayName("시작 시각이 주어지면 이후 주문 목록을 조회했을 때 created_at 필터를 포함한 GraphQL 요청을 전송해야 한다")
+    void getOrdersSince_includesCreatedAtFilter() {
+        LocalDateTime since = LocalDateTime.of(2026, 4, 11, 9, 0);
+
+        mockServer.expect(requestTo(graphqlUrl()))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().string(containsString("created_at:>'2026-04-11T09:00Z'")))
+                .andRespond(withSuccess(ordersResponseJson(), MediaType.APPLICATION_JSON));
+
+        client.getOrdersSince(STORE_NAME, ACCESS_TOKEN, since);
+        mockServer.verify();
+    }
+
+    @Test
+    @DisplayName("다음 페이지가 있으면 이후 주문 건수를 조회했을 때 모든 페이지를 순회해 전체 건수를 반환해야 한다")
+    void countOrdersSince_fetchesAllPages() {
+        LocalDateTime since = LocalDateTime.of(2026, 4, 11, 9, 0);
+
+        mockServer.expect(requestTo(graphqlUrl()))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().string(containsString("created_at:>'2026-04-11T09:00Z'")))
+                .andRespond(withSuccess(pagedOrdersResponseJson(true, "cursor-1", 250), MediaType.APPLICATION_JSON));
+
+        mockServer.expect(requestTo(graphqlUrl()))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().string(containsString("after: \\\"cursor-1\\\"")))
+                .andRespond(withSuccess(pagedOrdersResponseJson(false, null, 20), MediaType.APPLICATION_JSON));
+
+        int total = client.countOrdersSince(STORE_NAME, ACCESS_TOKEN, since);
+
+        assertThat(total).isEqualTo(270);
+        mockServer.verify();
     }
 
     // ─────────────────────────────────────────────────────────
@@ -233,5 +270,41 @@ class ShopifyOrderClientTest {
                   }
                 }
                 """;
+    }
+
+    private String pagedOrdersResponseJson(boolean hasNextPage, String endCursor, int edgeCount) {
+        StringBuilder edges = new StringBuilder();
+        for (int i = 0; i < edgeCount; i++) {
+            if (i > 0) {
+                edges.append(",");
+            }
+            edges.append("""
+                    {
+                      "node": {
+                        "id": "gid://shopify/Order/%d",
+                        "name": "#%d",
+                        "email": "paged@test.com",
+                        "createdAt": "2024-01-15T10:00:00-05:00",
+                        "shippingAddress": null,
+                        "fulfillmentOrders": { "edges": [] }
+                      }
+                    }
+                    """.formatted(2000 + i, 2000 + i));
+        }
+
+        String cursorJson = endCursor == null ? "null" : "\"" + endCursor + "\"";
+        return """
+                {
+                  "data": {
+                    "orders": {
+                      "edges": [%s],
+                      "pageInfo": {
+                        "hasNextPage": %s,
+                        "endCursor": %s
+                      }
+                    }
+                  }
+                }
+                """.formatted(edges, hasNextPage, cursorJson);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 셀러 주문 등록 화면에서 사용하는 `POST /integrations/seller/channels/{channelKey}/import-preview` API를 추가했습니다.
- preview는 저장 없이 Shopify 주문을 조회하고 `pendingOrders`, `lastSyncedAt`만 반환하도록 구현했습니다.
- preview 기준 시각은 `ChannelOrder.createdAt` 최신값으로 계산하고, 최신값이 없을 때만 `syncWindow`를 fallback으로 사용합니다.
- Shopify preview count가 첫 페이지 250건에서 잘리지 않도록 `pageInfo.hasNextPage`, `endCursor` 기반 페이지네이션을 추가했습니다.

```mermaid
flowchart LR
  FE["SellerOrderRegisterView.handleChannelImportPreview"] --> C["IntegrationCommandController.importChannelPreview"]
  C --> S["SellerChannelImportPreviewService.preview"]
  S --> R["ChannelOrderRepository.findFirstBySellerIdAndOrderChannelOrderByAuditCreatedAtDesc"]
  S --> Q["ChannelApiQueryService.findShopifyCredential"]
  S --> API["ShopifyOrderClient.countOrdersSince"]
  API --> API2["pageInfo.hasNextPage 반복 조회"]
  API2 --> S
  S --> C
```

## 📂 관련 파일 (Scope)
- `src/main/java/com/conk/integration/command/application/controller/IntegrationCommandController.java`
- `src/main/java/com/conk/integration/command/application/dto/request/SellerChannelImportPreviewRequest.java`
- `src/main/java/com/conk/integration/command/application/dto/response/SellerChannelImportPreviewResponse.java`
- `src/main/java/com/conk/integration/command/application/dto/response/ShopifyOrderResponse.java`
- `src/main/java/com/conk/integration/command/application/service/SellerChannelImportPreviewService.java`
- `src/main/java/com/conk/integration/command/infrastructure/repository/ChannelOrderRepository.java`
- `src/main/java/com/conk/integration/command/infrastructure/service/ShopifyOrderClient.java`
- `src/test/java/com/conk/integration/command/application/controller/IntegrationCommandControllerTest.java`
- `src/test/java/com/conk/integration/command/application/service/SellerChannelImportPreviewServiceTest.java`
- `src/test/java/com/conk/integration/command/infrastructure/service/ShopifyOrderClientTest.java`

## 🎯 관련 이슈
- Closes #35

## ⚠️ 유의사항 및 특이사항
- preview count는 Shopify GraphQL 페이지를 모두 순회해 누적 계산합니다.
- `created_at` 필터 시각은 현재 구현상 `LocalDateTime -> UTC offset` 문자열로 전송합니다.
- 실제 운영 환경의 서버/DB 시간대 정책이 UTC가 아니면 시각 해석을 추가로 맞출 필요가 있습니다.

## ✅ 체크리스트
- [x] 커밋 내역이 정리되어 있는가?
- [x] 불필요한 파일이 없는가?